### PR TITLE
Fix socks5 client auth methods

### DIFF
--- a/connector/socks/v5/connector.go
+++ b/connector/socks/v5/connector.go
@@ -61,6 +61,9 @@ func (c *socks5Connector) Init(md md.Metadata) (err error) {
 				InsecureSkipVerify: true,
 			}
 		}
+		if selector.User != nil {
+			selector.methods = append(selector.methods, socks.MethodTLSAuth)
+		}
 	}
 	c.selector = selector
 

--- a/connector/socks/v5/connector.go
+++ b/connector/socks/v5/connector.go
@@ -46,11 +46,13 @@ func (c *socks5Connector) Init(md md.Metadata) (err error) {
 	selector := &clientSelector{
 		methods: []uint8{
 			gosocks5.MethodNoAuth,
-			gosocks5.MethodUserPass,
 		},
 		User:      c.options.Auth,
 		TLSConfig: c.options.TLSConfig,
 		logger:    c.options.Logger,
+	}
+	if selector.User != nil {
+		selector.methods = append(selector.methods, gosocks5.MethodUserPass)
 	}
 	if !c.md.noTLS {
 		selector.methods = append(selector.methods, socks.MethodTLS)


### PR DESCRIPTION
Change Socks5 connector to provide MethodUserPass and MethodTLSAuth when auth configured and do not when not
Solve #6 issue
