### PR TITLE
feat: enhance icmp tunnel

### DIFF
--- a/dialer/icmp/dialer.go
+++ b/dialer/icmp/dialer.go
@@ -81,7 +81,11 @@ func (d *icmpDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialO
 			id = rand.New(rand.NewSource(time.Now().UnixNano())).Intn(math.MaxUint16) + 1
 			raddr.Port = id
 		}
-		pc = icmp_pkg.ClientConn(pc, id)
+		if d.md.seqBySeqMode {
+			pc = icmp_pkg.ClientConn2(pc, raddr)
+		} else {
+			pc = icmp_pkg.ClientConn(pc, id)
+		}
 
 		session, err = d.initSession(ctx, raddr, pc)
 		if err != nil {

--- a/dialer/icmp/metadata.go
+++ b/dialer/icmp/metadata.go
@@ -11,6 +11,7 @@ type metadata struct {
 	keepAlivePeriod  time.Duration
 	maxIdleTimeout   time.Duration
 	handshakeTimeout time.Duration
+	seqBySeqMode     bool
 }
 
 func (d *icmpDialer) parseMetadata(md mdata.Metadata) (err error) {
@@ -19,6 +20,7 @@ func (d *icmpDialer) parseMetadata(md mdata.Metadata) (err error) {
 		keepAlivePeriod  = "ttl"
 		handshakeTimeout = "handshakeTimeout"
 		maxIdleTimeout   = "maxIdleTimeout"
+		seqBySeqMode     = "seqBySeqMode"
 	)
 
 	if mdutil.GetBool(md, keepAlive) {
@@ -29,6 +31,7 @@ func (d *icmpDialer) parseMetadata(md mdata.Metadata) (err error) {
 	}
 	d.md.handshakeTimeout = mdutil.GetDuration(md, handshakeTimeout)
 	d.md.maxIdleTimeout = mdutil.GetDuration(md, maxIdleTimeout)
+	d.md.seqBySeqMode = mdutil.GetBool(md, seqBySeqMode)
 
 	return
 }

--- a/listener/icmp/listener.go
+++ b/listener/icmp/listener.go
@@ -56,7 +56,11 @@ func (l *icmpListener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return
 	}
-	conn = icmp_pkg.ServerConn(conn)
+	if l.md.seqBySeqMode {
+		conn = icmp_pkg.ServerConn2(conn)
+	} else {
+		conn = icmp_pkg.ServerConn(conn)
+	}
 	conn = metrics.WrapPacketConn(l.options.Service, conn)
 	conn = stats.WrapPacketConn(conn, l.options.Stats)
 	conn = admission.WrapPacketConn(l.options.Admission, conn)

--- a/listener/icmp/metadata.go
+++ b/listener/icmp/metadata.go
@@ -16,7 +16,8 @@ type metadata struct {
 	handshakeTimeout time.Duration
 	maxIdleTimeout   time.Duration
 
-	backlog int
+	backlog      int
+	seqBySeqMode bool
 }
 
 func (l *icmpListener) parseMetadata(md mdata.Metadata) (err error) {
@@ -26,7 +27,8 @@ func (l *icmpListener) parseMetadata(md mdata.Metadata) (err error) {
 		handshakeTimeout = "handshakeTimeout"
 		maxIdleTimeout   = "maxIdleTimeout"
 
-		backlog = "backlog"
+		backlog      = "backlog"
+		seqBySeqMode = "seqBySeqMode"
 	)
 
 	l.md.backlog = mdutil.GetInt(md, backlog)
@@ -42,6 +44,10 @@ func (l *icmpListener) parseMetadata(md mdata.Metadata) (err error) {
 	}
 	l.md.handshakeTimeout = mdutil.GetDuration(md, handshakeTimeout)
 	l.md.maxIdleTimeout = mdutil.GetDuration(md, maxIdleTimeout)
+
+	if mdutil.GetBool(md, seqBySeqMode) {
+		l.md.seqBySeqMode = true
+	}
 
 	return
 }


### PR DESCRIPTION
添加了seqBySeqMode参数
主要针对严格同个seq的icmp包一个出一个进不能进更多的防火墙优化
给server设计了一个seq队列，client会预先发送几个seq给server备用，server send packet时取用即可
不知道师傅有没有兴趣把这个实现合并到主线