### PR TITLE
fix QUIC error "CRYPTO_ERROR 0x178 (remote): tls: no application protocol"

### DIFF
--- a/dialer/icmp/dialer.go
+++ b/dialer/icmp/dialer.go
@@ -115,7 +115,7 @@ func (d *icmpDialer) initSession(ctx context.Context, addr net.Addr, conn net.Pa
 	}
 
 	tlsCfg := d.options.TLSConfig
-	tlsCfg.NextProtos = []string{"http/3", "quic/v1"}
+	tlsCfg.NextProtos = []string{"h3", "quic/v1"}
 
 	session, err := quic.DialEarly(ctx, conn, addr, tlsCfg, quicConfig)
 	if err != nil {

--- a/dialer/quic/dialer.go
+++ b/dialer/quic/dialer.go
@@ -114,7 +114,7 @@ func (d *quicDialer) initSession(ctx context.Context, addr net.Addr, conn net.Pa
 	}
 
 	tlsCfg := d.options.TLSConfig
-	tlsCfg.NextProtos = []string{"http/3", "quic/v1"}
+	tlsCfg.NextProtos = []string{"h3", "quic/v1"}
 
 	session, err := quic.DialEarly(ctx, conn, addr, tlsCfg, quicConfig)
 	if err != nil {

--- a/listener/icmp/listener.go
+++ b/listener/icmp/listener.go
@@ -73,7 +73,7 @@ func (l *icmpListener) Init(md md.Metadata) (err error) {
 	}
 
 	tlsCfg := l.options.TLSConfig
-	tlsCfg.NextProtos = []string{"http/3", "quic/v1"}
+	tlsCfg.NextProtos = []string{"h3", "quic/v1"}
 
 	ln, err := quic.ListenEarly(conn, tlsCfg, config)
 	if err != nil {

--- a/listener/quic/listener.go
+++ b/listener/quic/listener.go
@@ -82,7 +82,7 @@ func (l *quicListener) Init(md md.Metadata) (err error) {
 	}
 
 	tlsCfg := l.options.TLSConfig
-	tlsCfg.NextProtos = []string{"http/3", "quic/v1"}
+	tlsCfg.NextProtos = []string{"h3", "quic/v1"}
 
 	ln, err := quic.ListenEarly(conn, tlsCfg, config)
 	if err != nil {


### PR DESCRIPTION
if I send request over QUIC to the foward QUIC port provide by gost, it will be:

```shell
[ERRO] do http request failed: Post "https://127.0.0.1:8082": CRYPTO_ERROR 0x178 (remote): tls: no application protocol
```

and it beacuse the `NextProtos` (aka ALPN identifiers) of the server (aka the foward QUIC port provide by gost) do not contains `h3`.

> I dont know why there is `http/3` as the ALPN identifier, I didn't find any doc about whether it is correct or not.

see:

https://github.com/quic-go/quic-go/blob/b52c33939de793a8ef282cb7a0f5abe1292d202c/http3/server.go#L36
