### PR TITLE
feat recorder: introduce metrics

### DIFF
--- a/config/parsing/recorder/parse.go
+++ b/config/parsing/recorder/parse.go
@@ -73,11 +73,17 @@ func ParseRecorder(cfg *config.RecorderConfig) (r recorder.Recorder) {
 			}
 		}
 
-		return xrecorder.FileRecorder(out, xrecorder.SepRecorderOption(cfg.File.Sep))
+		return xrecorder.FileRecorder(out,
+			xrecorder.RecorderFileRecorderOption(cfg.Name),
+			xrecorder.SepFileRecorderOption(cfg.File.Sep),
+		)
 	}
 
 	if cfg.TCP != nil && cfg.TCP.Addr != "" {
-		return xrecorder.TCPRecorder(cfg.TCP.Addr, xrecorder.TimeoutTCPRecorderOption(cfg.TCP.Timeout))
+		return xrecorder.TCPRecorder(cfg.TCP.Addr,
+			xrecorder.RecorderTCPRecorderOption(cfg.Name),
+			xrecorder.TimeoutTCPRecorderOption(cfg.TCP.Timeout),
+		)
 	}
 
 	if cfg.HTTP != nil && cfg.HTTP.URL != "" {
@@ -86,6 +92,7 @@ func ParseRecorder(cfg *config.RecorderConfig) (r recorder.Recorder) {
 			h.Add(k, v)
 		}
 		return xrecorder.HTTPRecorder(cfg.HTTP.URL,
+			xrecorder.RecorderHTTPRecorderOption(cfg.Name),
 			xrecorder.TimeoutHTTPRecorderOption(cfg.HTTP.Timeout),
 			xrecorder.HeaderHTTPRecorderOption(h),
 		)
@@ -97,6 +104,7 @@ func ParseRecorder(cfg *config.RecorderConfig) (r recorder.Recorder) {
 		switch cfg.Redis.Type {
 		case "list": // redis list
 			return xrecorder.RedisListRecorder(cfg.Redis.Addr,
+				xrecorder.RecorderRedisRecorderOption(cfg.Name),
 				xrecorder.DBRedisRecorderOption(cfg.Redis.DB),
 				xrecorder.KeyRedisRecorderOption(cfg.Redis.Key),
 				xrecorder.UsernameRedisRecorderOption(cfg.Redis.Username),
@@ -104,6 +112,7 @@ func ParseRecorder(cfg *config.RecorderConfig) (r recorder.Recorder) {
 			)
 		case "sset": // sorted set
 			return xrecorder.RedisSortedSetRecorder(cfg.Redis.Addr,
+				xrecorder.RecorderRedisRecorderOption(cfg.Name),
 				xrecorder.DBRedisRecorderOption(cfg.Redis.DB),
 				xrecorder.KeyRedisRecorderOption(cfg.Redis.Key),
 				xrecorder.UsernameRedisRecorderOption(cfg.Redis.Username),
@@ -111,6 +120,7 @@ func ParseRecorder(cfg *config.RecorderConfig) (r recorder.Recorder) {
 			)
 		default: // redis set
 			return xrecorder.RedisSetRecorder(cfg.Redis.Addr,
+				xrecorder.RecorderRedisRecorderOption(cfg.Name),
 				xrecorder.DBRedisRecorderOption(cfg.Redis.DB),
 				xrecorder.KeyRedisRecorderOption(cfg.Redis.Key),
 				xrecorder.UsernameRedisRecorderOption(cfg.Redis.Username),

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,27 +9,29 @@ import (
 const (
 	// Number of services. Labels: host.
 	MetricServicesGauge metrics.MetricName = "gost_services"
-	// Total service requests. Labels: host, service.
+	// Total service requests. Labels: host, service, client.
 	MetricServiceRequestsCounter metrics.MetricName = "gost_service_requests_total"
-	// Number of in-flight requests. Labels: host, service.
+	// Number of in-flight requests. Labels: host, service, client.
 	MetricServiceRequestsInFlightGauge metrics.MetricName = "gost_service_requests_in_flight"
-	// Request duration historgram. Labels: host, service.
+	// Request duration histogram. Labels: host, service.
 	MetricServiceRequestsDurationObserver metrics.MetricName = "gost_service_request_duration_seconds"
-	// Total service input data transfer size in bytes. Labels: host, service.
+	// Total service input data transfer size in bytes. Labels: host, service, client.
 	MetricServiceTransferInputBytesCounter metrics.MetricName = "gost_service_transfer_input_bytes_total"
-	// Total service output data transfer size in bytes. Labels: host, service.
+	// Total service output data transfer size in bytes. Labels: host, service, client.
 	MetricServiceTransferOutputBytesCounter metrics.MetricName = "gost_service_transfer_output_bytes_total"
 	// Chain node connect duration histogram. Labels: host, chain, node.
 	MetricNodeConnectDurationObserver metrics.MetricName = "gost_chain_node_connect_duration_seconds"
-	// Total service handler errors. Labels: host, service.
+	// Total service handler errors. Labels: host, service, client.
 	MetricServiceHandlerErrorsCounter metrics.MetricName = "gost_service_handler_errors_total"
 	// Total chain connect errors. Labels: host, chain, node.
 	MetricChainErrorsCounter metrics.MetricName = "gost_chain_errors_total"
+	// Total recorder records. Labels: host, recorder.
+	MetricRecorderRecordsCounter metrics.MetricName = "gost_recorder_records_total"
 )
 
 var (
 	defaultMetrics metrics.Metrics = NewMetrics()
-	enabled atomic.Bool
+	enabled        atomic.Bool
 )
 
 func Enable(b bool) {

--- a/metrics/prom.go
+++ b/metrics/prom.go
@@ -63,6 +63,12 @@ func NewMetrics() metrics.Metrics {
 					Help: "Total chain errors",
 				},
 				[]string{"host", "chain", "node"}),
+			MetricRecorderRecordsCounter: prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Name: string(MetricRecorderRecordsCounter),
+					Help: "Total records written by recorder",
+				},
+				[]string{"host", "recorder"}),
 		},
 		histograms: map[metrics.MetricName]*prometheus.HistogramVec{
 			MetricServiceRequestsDurationObserver: prometheus.NewHistogramVec(

--- a/recorder/redis.go
+++ b/recorder/redis.go
@@ -3,17 +3,26 @@ package recorder
 import (
 	"context"
 
+	"github.com/go-gost/core/metrics"
 	"github.com/go-gost/core/recorder"
+	xmetrics "github.com/go-gost/x/metrics"
 	"github.com/go-redis/redis/v8"
 )
 
 type redisRecorderOptions struct {
+	recorder string
 	db       int
 	username string
 	password string
 	key      string
 }
 type RedisRecorderOption func(opts *redisRecorderOptions)
+
+func RecorderRedisRecorderOption(recorder string) RedisRecorderOption {
+	return func(opts *redisRecorderOptions) {
+		opts.recorder = recorder
+	}
+}
 
 func DBRedisRecorderOption(db int) RedisRecorderOption {
 	return func(opts *redisRecorderOptions) {
@@ -39,8 +48,9 @@ func KeyRedisRecorderOption(key string) RedisRecorderOption {
 }
 
 type redisSetRecorder struct {
-	client *redis.Client
-	key    string
+	recorder string
+	client   *redis.Client
+	key      string
 }
 
 // RedisSetRecorder records data to a redis set.
@@ -51,6 +61,7 @@ func RedisSetRecorder(addr string, opts ...RedisRecorderOption) recorder.Recorde
 	}
 
 	return &redisSetRecorder{
+		recorder: options.recorder,
 		client: redis.NewClient(&redis.Options{
 			Addr:     addr,
 			Password: options.password,
@@ -61,6 +72,8 @@ func RedisSetRecorder(addr string, opts ...RedisRecorderOption) recorder.Recorde
 }
 
 func (r *redisSetRecorder) Record(ctx context.Context, b []byte, opts ...recorder.RecordOption) error {
+	xmetrics.GetCounter(xmetrics.MetricRecorderRecordsCounter, metrics.Labels{"recorder": r.recorder}).Inc()
+
 	if r.key == "" {
 		return nil
 	}
@@ -73,8 +86,9 @@ func (r *redisSetRecorder) Close() error {
 }
 
 type redisListRecorder struct {
-	client *redis.Client
-	key    string
+	recorder string
+	client   *redis.Client
+	key      string
 }
 
 // RedisListRecorder records data to a redis list.
@@ -85,6 +99,7 @@ func RedisListRecorder(addr string, opts ...RedisRecorderOption) recorder.Record
 	}
 
 	return &redisListRecorder{
+		recorder: options.recorder,
 		client: redis.NewClient(&redis.Options{
 			Addr:     addr,
 			Password: options.password,
@@ -95,6 +110,8 @@ func RedisListRecorder(addr string, opts ...RedisRecorderOption) recorder.Record
 }
 
 func (r *redisListRecorder) Record(ctx context.Context, b []byte, opts ...recorder.RecordOption) error {
+	xmetrics.GetCounter(xmetrics.MetricRecorderRecordsCounter, metrics.Labels{"recorder": r.recorder}).Inc()
+
 	if r.key == "" {
 		return nil
 	}
@@ -107,8 +124,9 @@ func (r *redisListRecorder) Close() error {
 }
 
 type redisSortedSetRecorder struct {
-	client *redis.Client
-	key    string
+	recorder string
+	client   *redis.Client
+	key      string
 }
 
 // RedisSortedSetRecorder records data to a redis sorted set.
@@ -119,6 +137,7 @@ func RedisSortedSetRecorder(addr string, opts ...RedisRecorderOption) recorder.R
 	}
 
 	return &redisSortedSetRecorder{
+		recorder: options.recorder,
 		client: redis.NewClient(&redis.Options{
 			Addr:     addr,
 			Password: options.password,
@@ -129,6 +148,8 @@ func RedisSortedSetRecorder(addr string, opts ...RedisRecorderOption) recorder.R
 }
 
 func (r *redisSortedSetRecorder) Record(ctx context.Context, b []byte, opts ...recorder.RecordOption) error {
+	xmetrics.GetCounter(xmetrics.MetricRecorderRecordsCounter, metrics.Labels{"recorder": r.recorder}).Inc()
+
 	if r.key == "" {
 		return nil
 	}


### PR DESCRIPTION
This merge request introduces a total counter metric for each recorder, which can be useful for end-to-end monitoring of the records pipeline, especially if the data is stored in a database.