### PR TITLE
fix bypass: prevent panic on invalid glob patterns

### DIFF
--- a/bypass/bypass.go
+++ b/bypass/bypass.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-gost/x/internal/matcher"
 	xnet "github.com/go-gost/x/internal/net"
 	xlogger "github.com/go-gost/x/logger"
+	"github.com/gobwas/glob"
 )
 
 var (
@@ -165,8 +166,10 @@ func (p *localBypass) reload(ctx context.Context) error {
 		}
 
 		if strings.ContainsAny(pattern, "*?") {
-			wildcards = append(wildcards, pattern)
-			continue
+			if _, err := glob.Compile(pattern); err == nil {
+				wildcards = append(wildcards, pattern)
+				continue
+			}
 		}
 
 		r := xnet.IPRange{}


### PR DESCRIPTION
Hi, @ginuerzh !

Please consider this patch to prevent panicking when bypass configuration contains invalid glob patterns.

```bash
go run github.com/go-gost/gost/cmd/gost@latest -L 'http://:8080?bypass=*[invalid'
# panic: unexpected end of input

# goroutine 82 [running]:
# github.com/gobwas/glob.MustCompile(...)
# 	/Users/denis/go/pkg/mod/github.com/gobwas/glob@v0.2.3/glob.go:57
# github.com/go-gost/x/internal/matcher.WildcardMatcher({0x1400004c5e0, 0x1, 0x1013ea512?})
# 	/Users/denis/go/pkg/mod/github.com/go-gost/x@v0.7.5/internal/matcher/matcher.go:201 +0x1cc
# github.com/go-gost/x/bypass.(*localBypass).reload(0x140004b41c0, {0x1019e3490?, 0x14000528780?})
# 	/Users/denis/go/pkg/mod/github.com/go-gost/x@v0.7.5/bypass/bypass.go:186 +0x5b8
# github.com/go-gost/x/bypass.(*localBypass).periodReload(0x140004b41c0, {0x1019e3490, 0x14000528780})
# 	/Users/denis/go/pkg/mod/github.com/go-gost/x@v0.7.5/bypass/bypass.go:121 +0x38
# created by github.com/go-gost/x/bypass.NewBypass in goroutine 1
# 	/Users/denis/go/pkg/mod/github.com/go-gost/x@v0.7.5/bypass/bypass.go:115 +0x1e8
# exit status 2
```