### PR TITLE
feat: support custom ComponentID for Windows TAP device configuration

### DIFF
--- a/internal/util/tap/config.go
+++ b/internal/util/tap/config.go
@@ -8,9 +8,10 @@ type Route struct {
 	Gateway net.IP
 }
 type Config struct {
-	Name    string
-	Net     string
-	MTU     int
-	Gateway string
-	Routes  []Route
+	Name        string
+	Net         string
+	MTU         int
+	Gateway     string
+	ComponentID string
+	Routes      []Route
 }

--- a/listener/tap/metadata.go
+++ b/listener/tap/metadata.go
@@ -19,22 +19,27 @@ type metadata struct {
 
 func (l *tapListener) parseMetadata(md mdata.Metadata) (err error) {
 	const (
-		name    = "name"
-		netKey  = "net"
-		mtu     = "mtu"
-		route   = "route"
-		routes  = "routes"
-		gateway = "gw"
+		name        = "name"
+		netKey      = "net"
+		mtu         = "mtu"
+		route       = "route"
+		routes      = "routes"
+		gateway     = "gw"
+		componentID = "componentID"
 	)
 
 	config := &tap_util.Config{
-		Name:    mdutil.GetString(md, name),
-		Net:     mdutil.GetString(md, netKey),
-		MTU:     mdutil.GetInt(md, mtu),
-		Gateway: mdutil.GetString(md, gateway),
+		Name:        mdutil.GetString(md, name),
+		Net:         mdutil.GetString(md, netKey),
+		MTU:         mdutil.GetInt(md, mtu),
+		Gateway:     mdutil.GetString(md, gateway),
+		ComponentID: mdutil.GetString(md, componentID),
 	}
 	if config.MTU <= 0 {
 		config.MTU = DefaultMTU
+	}
+	if config.ComponentID == "" {
+		config.ComponentID = "tap0901"
 	}
 
 	gw := net.ParseIP(config.Gateway)

--- a/listener/tap/tap_windows.go
+++ b/listener/tap/tap_windows.go
@@ -17,7 +17,7 @@ func (l *tapListener) createTap() (dev io.ReadWriteCloser, name string, ip net.I
 	ifce, err := water.New(water.Config{
 		DeviceType: water.TAP,
 		PlatformSpecificParams: water.PlatformSpecificParams{
-			ComponentID:   "tap0901",
+			ComponentID:   l.md.config.ComponentID,
 			InterfaceName: l.md.config.Name,
 			Network:       l.md.config.Net,
 		},


### PR DESCRIPTION
On Windows, TAP devices may have different registry ComponentID values after installation.
For example, some environments report `root\tap0901` instead of the default `tap0901`.
This causes initialization errors such as:

```
Failed to find the tap device in registry with specified ComponentId 'tap0901', TAP driver may be not installed
```

This change allows users to explicitly set the ComponentID in configuration.
For example:
```
gost -L=tap://:0/example.com:8421?componentID=root\tap0901
```