### PR TITLE
add SetReadDeadline in Pipe, to prevent memory not auto release in mw…

### DIFF
--- a/internal/net/pipe.go
+++ b/internal/net/pipe.go
@@ -3,7 +3,6 @@ package net
 import (
 	"context"
 	"io"
-	"sync"
 	"time"
 
 	"github.com/go-gost/core/common/bufpool"
@@ -13,69 +12,133 @@ import (
 const (
 	// tcpWaitTimeout implements a TCP half-close timeout.
 	tcpWaitTimeout = 10 * time.Second
+	readTimeout    = 30 * time.Second
 )
 
+// Pipe 在两个连接之间建立双向数据通道
 func Pipe(ctx context.Context, rw1, rw2 io.ReadWriteCloser) error {
-	wg := sync.WaitGroup{}
-	wg.Add(2)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	ch := make(chan error, 2)
+	errCh := make(chan error, 2)
+
+	// 启动两个方向的传输
+	go func() {
+		errCh <- pipeHalf(ctx, rw1, rw2)
+	}()
 
 	go func() {
-		defer wg.Done()
-		if err := pipeBuffer(rw1, rw2, bufferSize/2); err != nil {
-			ch <- err
+		errCh <- pipeHalf(ctx, rw2, rw1)
+	}()
+
+	// 等待第一个错误或完成
+	var firstErr error
+	for i := 0; i < 2; i++ {
+		select {
+		case err := <-errCh:
+			if firstErr == nil && err != nil {
+				firstErr = err
+				cancel() // 一个方向出错，取消另一个
+			}
+		case <-ctx.Done():
+			// 超时或主动取消
+			forceClose(rw1, rw2)
+			return ctx.Err()
 		}
-	}()
-	go func() {
-		defer wg.Done()
-		if err := pipeBuffer(rw2, rw1, bufferSize/2); err != nil {
-			ch <- err
-		}
-	}()
-
-	done := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-	case <-ctx.Done():
-		return nil
 	}
 
-	select {
-	case err := <-ch:
-		return err
-	default:
-	}
-
-	return nil
+	return firstErr
 }
 
-func pipeBuffer(dst io.ReadWriteCloser, src io.ReadWriteCloser, bufferSize int) error {
-	buf := bufpool.Get(bufferSize)
+// pipeHalf 单向管道传输
+func pipeHalf(ctx context.Context, src, dst io.ReadWriteCloser) error {
+	defer func() {
+		// 传输完成后执行TCP半关闭
+		halfClose(src, dst)
+	}()
+
+	buf := bufpool.Get(bufferSize / 2)
 	defer bufpool.Put(buf)
 
-	_, err := io.CopyBuffer(dst, src, buf)
 
-	// Do the upload/download side TCP half-close.
+	// 创建带超时的读取器
+	reader := &readDeadliner{
+		Reader: src,
+		ctx:    ctx,
+	}
+
+	// 循环读取并写入，每次读取都有超时
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			// 设置读取超时
+			if rd, ok := src.(interface{ SetReadDeadline(time.Time) error }); ok {
+				rd.SetReadDeadline(time.Now().Add(readTimeout))
+			}
+
+			// 读取数据
+			nr, err := reader.Read(buf)
+			if err != nil {
+				if err != io.EOF {
+					return err
+				}
+				return nil // 正常结束
+			}
+
+			// 写入数据
+			_, err = dst.Write(buf[:nr])
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// readDeadliner 包装读取器，支持上下文取消
+type readDeadliner struct {
+	io.Reader
+	ctx context.Context
+}
+
+func (r *readDeadliner) Read(p []byte) (int, error) {
+	// 检查上下文是否已取消
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	default:
+	}
+	return r.Reader.Read(p)
+}
+
+// halfClose 执行TCP半关闭
+func halfClose(src, dst io.ReadWriteCloser) {
+	// 关闭读取端
 	if cr, ok := src.(xio.CloseRead); ok {
 		cr.CloseRead()
 	}
 
+	// 关闭写入端，尝试半关闭
 	if cw, ok := dst.(xio.CloseWrite); ok {
-		if e := cw.CloseWrite(); e == xio.ErrUnsupported {
-			dst.Close()
+		if err := cw.CloseWrite(); err == xio.ErrUnsupported {
+			dst.Close() // 不支持半关闭，完全关闭
 		} else {
-			// Set TCP half-close timeout.
-			xio.SetReadDeadline(dst, time.Now().Add(tcpWaitTimeout))
+			// 设置半关闭超时
+			if rd, ok := dst.(interface{ SetReadDeadline(time.Time) error }); ok {
+				rd.SetReadDeadline(time.Now().Add(tcpWaitTimeout))
+			}
 		}
 	} else {
-		dst.Close()
+		dst.Close() // 不支持CloseWrite，完全关闭
 	}
+}
 
-	return err
+// forceClose 强制关闭两个连接
+func forceClose(conns ...io.ReadWriteCloser) {
+	for _, conn := range conns {
+		if conn != nil {
+			conn.Close()
+		}
+	}
 }


### PR DESCRIPTION
mws/mtcp我遇到了server端内存泄漏的问题, 
尝试通过pipe方法加入SetReadDeadline来解决，避免很多内存堆积在pool buffer里
代码由ai辅助编写
调试日志
```
File: gost.so
Build ID: 4bd2d2d14d4c73565ed56759f2f167b7346f94cf
Type: alloc_space
Time: 2025-12-27 11:20:58 CST
Showing nodes accounting for 1382.40MB, 100% of 1382.40MB total
----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context 	 	 
----------------------------------------------------------+-------------
                                          572.52MB   100% |   io.Copy /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/io/io.go:388
  572.52MB 41.42% 41.42%   572.52MB 41.42%                | io.copyBuffer /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/io/io.go:426
----------------------------------------------------------+-------------
                                          148.03MB   100% |   sync.(*Pool).Get /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/sync/pool.go:155
  148.03MB 10.71% 52.12%   148.03MB 10.71%                | github.com/go-gost/core/common/bufpool.init.func8 /home/swz/go/pkg/mod/github.com/go-gost/core@v0.3.3/common/bufpool/pool.go:79
----------------------------------------------------------+-------------
                                          109.53MB   100% |   io.ReadAtLeast /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/io/io.go:335
  109.53MB  7.92% 60.05%   109.53MB  7.92%                | github.com/go-gost/x/metrics/wrapper.(*serverConn).Read /mnt/nvme1/swz/git/x/metrics/wrapper/conn.go:47
----------------------------------------------------------+-------------
                                           71.53MB   100% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
   71.53MB  5.17% 65.22%    71.53MB  5.17%                | github.com/sirupsen/logrus.(*Entry).WithFields /home/swz/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:126
----------------------------------------------------------+-------------
                                           52.51MB   100% |   github.com/xtaci/smux.(*Session).sendLoop /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/session.go:551
   52.51MB  3.80% 69.02%    52.51MB  3.80%                | github.com/go-gost/x/metrics/wrapper.(*serverConn).Write /mnt/nvme1/swz/git/x/metrics/wrapper/conn.go:60
----------------------------------------------------------+-------------
                                           33.01MB   100% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
   33.01MB  2.39% 71.41%    33.01MB  2.39%                | github.com/sirupsen/logrus.(*Entry).WithFields /home/swz/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:128
----------------------------------------------------------+-------------
                                              25MB   100% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
      25MB  1.81% 73.22%       25MB  1.81%                | github.com/sirupsen/logrus.(*Entry).WithFields /home/swz/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:150
----------------------------------------------------------+-------------
                                           23.55MB   100% |   runtime.newm /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/runtime/proc.go:2861
   23.55MB  1.70% 74.92%    23.55MB  1.70%                | runtime.allocm /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/runtime/proc.go:2325
----------------------------------------------------------+-------------
                                           16.50MB 80.49% |   github.com/xtaci/smux.(*stream).writeV2 /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/stream.go:454
                                            2.50MB 12.20% |   github.com/xtaci/smux.(*stream).sendWindowUpdate /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/stream.go:302
                                            1.50MB  7.32% |   github.com/xtaci/smux.(*stream).Close /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/stream.go:501
   20.50MB  1.48% 76.40%    20.50MB  1.48%                | github.com/xtaci/smux.(*Session).writeFrameInternal /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/session.go:591
----------------------------------------------------------+-------------
                                           15.51MB   100% |   github.com/sirupsen/logrus.(*Entry).write /home/swz/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:289
   15.51MB  1.12% 77.52%    15.51MB  1.12%                | github.com/sirupsen/logrus.(*JSONFormatter).Format /home/swz/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/json_formatter.go:64
----------------------------------------------------------+-------------
                                           21.50MB   100% |   github.com/go-gost/x/chain.(*Router).dial /mnt/nvme1/swz/git/x/chain/router.go:106
    9.50MB  0.69% 78.21%    21.50MB  1.56%                | github.com/go-gost/x/internal/net.Resolve /mnt/nvme1/swz/git/x/internal/net/resovle.go:27
                                              11MB 51.16% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
                                               1MB  4.65% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:99
----------------------------------------------------------+-------------
                                            8.50MB 94.44% |   net.(*TCPAddr).String /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/net/tcpsock.go:52 (inline)
                                            0.50MB  5.56% |   net.(*UDPAddr).String /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/net/udpsock.go:52 (inline)
       9MB  0.65% 78.86%        9MB  0.65%                | net.JoinHostPort /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/net/ipsock.go:242
----------------------------------------------------------+-------------
                                           32.01MB   100% |   github.com/go-gost/x/service.(*defaultService).Serve.func1 /mnt/nvme1/swz/git/x/service/service.go:280
    8.50MB  0.62% 79.48%    32.01MB  2.32%                | github.com/go-gost/x/handler/relay.(*relayHandler).Handle /mnt/nvme1/swz/git/x/handler/relay/handler.go:221
                                           23.01MB 71.88% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
                                            0.50MB  1.56% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:99
----------------------------------------------------------+-------------
                                              20MB   100% |   main.(*program).run.func1 /mnt/nvme1/swz/git/gost/cmd/gost/program.go:83
    8.50MB  0.62% 80.09%       20MB  1.45%                | github.com/go-gost/x/service.(*defaultService).Serve /mnt/nvme1/swz/git/x/service/service.go:220
                                           11.50MB 57.50% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
----------------------------------------------------------+-------------
                                           20.51MB   100% |   github.com/go-gost/x/handler/relay.(*relayHandler).handleConnect /mnt/nvme1/swz/git/x/handler/relay/connect.go:108
    8.50MB  0.62% 80.71%    20.51MB  1.48%                | github.com/go-gost/x/chain.(*Router).Dial /mnt/nvme1/swz/git/x/chain/router.go:53
                                              12MB 58.54% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
----------------------------------------------------------+-------------
                                               3MB 35.29% |   github.com/go-gost/x/internal/ctx.ContextWithBuffer /mnt/nvme1/swz/git/x/internal/ctx/value.go:15
                                            2.50MB 29.41% |   github.com/go-gost/x/ctx.ContextWithSrcAddr /mnt/nvme1/swz/git/x/ctx/value.go:19
                                            1.50MB 17.65% |   github.com/go-gost/x/ctx.ContextWithDstAddr /mnt/nvme1/swz/git/x/ctx/value.go:30
                                            1.50MB 17.65% |   github.com/go-gost/x/ctx.ContextWithSid /mnt/nvme1/swz/git/x/ctx/value.go:49
    8.50MB  0.61% 81.32%     8.50MB  0.61%                | context.WithValue /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/context/context.go:735
----------------------------------------------------------+-------------
    7.50MB  0.54% 81.87%     7.50MB  0.54%                | github.com/go-gost/x/service.(*defaultService).Serve.func1 /mnt/nvme1/swz/git/x/service/service.go:267
----------------------------------------------------------+-------------
                                           27.01MB   100% |   github.com/go-gost/x/handler/relay.(*relayHandler).Handle /mnt/nvme1/swz/git/x/handler/relay/handler.go:230
    7.50MB  0.54% 82.41%    27.01MB  1.95%                | github.com/go-gost/x/handler/relay.(*relayHandler).handleConnect /mnt/nvme1/swz/git/x/handler/relay/connect.go:36
                                           19.01MB 70.38% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
                                            0.50MB  1.85% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:99
----------------------------------------------------------+-------------
    7.50MB  0.54% 82.95%     7.50MB  0.54%                | github.com/xtaci/smux.(*Session).shaperLoop /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/session.go:510
----------------------------------------------------------+-------------
                                            7.50MB   100% |   container/heap.Pop /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/container/heap/heap.go:63
    7.50MB  0.54% 83.49%     7.50MB  0.54%                | github.com/xtaci/smux.(*shaperHeap).Pop /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/shaper.go:55
----------------------------------------------------------+-------------
                                           19.50MB   100% |   github.com/go-gost/x/chain.(*defaultRoute).Dial /mnt/nvme1/swz/git/x/chain/route.go:47
       7MB  0.51% 84.00%    19.50MB  1.41%                | github.com/go-gost/x/internal/net/dialer.(*Dialer).Dial /mnt/nvme1/swz/git/x/internal/net/dialer/dialer.go:43
                                           12.50MB 64.10% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
----------------------------------------------------------+-------------
    6.50MB  0.47% 84.47%     6.50MB  0.47%                | github.com/go-gost/x/service.(*defaultService).Serve.func1 /mnt/nvme1/swz/git/x/service/service.go:262
----------------------------------------------------------+-------------
                                            6.50MB   100% |   net.ipEmptyString /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/net/ip.go:332
    6.50MB  0.47% 84.94%     6.50MB  0.47%                | net.IP.String /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/net/ip.go:315
----------------------------------------------------------+-------------
                                               6MB   100% |   github.com/sirupsen/logrus.(*Entry).log /home/swz/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:224 (inline)
       6MB  0.43% 85.37%        6MB  0.43%                | github.com/sirupsen/logrus.(*Entry).Dup /home/swz/go/pkg/mod/github.com/sirupsen/logrus@v1.9.3/entry.go:84
----------------------------------------------------------+-------------
                                           21.01MB   100% |   github.com/go-gost/x/handler/relay.(*relayHandler).Handle /mnt/nvme1/swz/git/x/handler/relay/handler.go:238
       6MB  0.43% 85.81%    21.01MB  1.52%                | github.com/go-gost/x/handler/relay.(*relayHandler).Handle.func1 /mnt/nvme1/swz/git/x/handler/relay/handler.go:145
                                           14.51MB 69.05% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
                                            0.50MB  2.38% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:99
----------------------------------------------------------+-------------
                                            5.50MB   100% |   encoding/json.(*encodeState).reflectValue /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/encoding/json/encode.go:367
    5.50MB   0.4% 86.21%     5.50MB   0.4%                | encoding/json.mapEncoder.encode /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/encoding/json/encode.go:795
----------------------------------------------------------+-------------
                                            5.50MB   100% |   github.com/xtaci/smux.(*Session).recvLoop /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/session.go:412
    5.50MB   0.4% 86.60%     5.50MB   0.4%                | github.com/xtaci/smux.(*stream).pushBytes /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/stream.go:572
----------------------------------------------------------+-------------
                                           13.50MB   100% |   github.com/go-gost/x/handler/relay.(*relayHandler).Handle /mnt/nvme1/swz/git/x/handler/relay/handler.go:230
       5MB  0.36% 86.97%    13.50MB  0.98%                | github.com/go-gost/x/handler/relay.(*relayHandler).handleConnect /mnt/nvme1/swz/git/x/handler/relay/connect.go:118
                                               7MB 51.86% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
                                            1.50MB 11.11% |   net.(*TCPAddr).String /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/net/tcpsock.go:52
----------------------------------------------------------+-------------
                                              12MB   100% |   github.com/go-gost/x/handler/relay.(*relayHandler).Handle /mnt/nvme1/swz/git/x/handler/relay/handler.go:230
       5MB  0.36% 87.33%       12MB  0.87%                | github.com/go-gost/x/handler/relay.(*relayHandler).handleConnect /mnt/nvme1/swz/git/x/handler/relay/connect.go:211
                                               7MB 58.34% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
----------------------------------------------------------+-------------
                                               5MB   100% |   github.com/xtaci/smux.(*Session).recvLoop /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/session.go:391 (inline)
       5MB  0.36% 87.69%        5MB  0.36%                | github.com/xtaci/smux.newStream /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/stream.go:78
----------------------------------------------------------+-------------
                                               5MB   100% |   github.com/xtaci/smux.(*Session).recvLoop /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/session.go:412
       5MB  0.36% 88.05%        5MB  0.36%                | github.com/xtaci/smux.(*stream).pushBytes /home/swz/go/pkg/mod/github.com/xtaci/smux@v1.5.31/stream.go:571
----------------------------------------------------------+-------------
                                            4.50MB   100% |   github.com/go-gost/x/service.(*defaultService).Serve.func1 /mnt/nvme1/swz/git/x/service/service.go:280
    4.50MB  0.33% 88.38%     4.50MB  0.33%                | github.com/go-gost/x/handler/relay.(*relayHandler).Handle /mnt/nvme1/swz/git/x/handler/relay/handler.go:108
----------------------------------------------------------+-------------
                                           16.51MB   100% |   github.com/go-gost/x/service.(*defaultService).Serve.func1 /mnt/nvme1/swz/git/x/service/service.go:280
    4.50MB  0.33% 88.70%    16.51MB  1.19%                | github.com/go-gost/x/handler/relay.(*relayHandler).Handle /mnt/nvme1/swz/git/x/handler/relay/handler.go:121
                                              12MB 72.73% |   github.com/go-gost/x/logger.(*logrusLogger).WithFields /mnt/nvme1/swz/git/x/logger/logger.go:100
----------------------------------------------------------+-------------
                                            4.50MB   100% |   github.com/go-gost/x/internal/net/dialer.(*Dialer).dialOnce /mnt/nvme1/swz/git/x/internal/net/dialer/dialer.go:179
    4.50MB  0.33% 89.03%     4.50MB  0.33%                | net.(*Dialer).DialContext /nix/store/3fd683jfggglpshxprz9mi5sz8wd3c9p-go-1.25.0/share/go/src/net/dial.go:565
----------------------------------------------------------+-------------
       4MB  0.29% 89.32%        4MB  0.29%                | github.com/go-gost/x/service.(*defaultService).Serve.func1 /mnt/nvme1/swz/git/x/service/service.go:274
```
 