### PR TITLE
feat: add custom header support to PHT protocol

### DIFF
--- a/dialer/pht/dialer.go
+++ b/dialer/pht/dialer.go
@@ -109,6 +109,7 @@ func (d *phtDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialOp
 			PushPath:      d.md.pushPath,
 			PullPath:      d.md.pullPath,
 			TLSEnabled:    d.tlsEnabled,
+			Header:        d.md.header,
 			Logger:        d.options.Logger,
 		}
 		d.clients[addr] = client

--- a/dialer/pht/metadata.go
+++ b/dialer/pht/metadata.go
@@ -1,6 +1,7 @@
 package pht
 
 import (
+	"net/http"
 	"strings"
 
 	mdata "github.com/go-gost/core/metadata"
@@ -19,6 +20,7 @@ type metadata struct {
 	pushPath      string
 	pullPath      string
 	host          string
+	header        http.Header
 }
 
 func (d *phtDialer) parseMetadata(md mdata.Metadata) (err error) {
@@ -27,6 +29,7 @@ func (d *phtDialer) parseMetadata(md mdata.Metadata) (err error) {
 		pushPath      = "pushPath"
 		pullPath      = "pullPath"
 		host          = "host"
+		header        = "header"
 	)
 
 	d.md.authorizePath = mdutil.GetString(md, authorizePath)
@@ -43,5 +46,15 @@ func (d *phtDialer) parseMetadata(md mdata.Metadata) (err error) {
 	}
 
 	d.md.host = mdutil.GetString(md, host)
+
+	// Parse custom headers
+	if m := mdutil.GetStringMapString(md, header); len(m) > 0 {
+		h := http.Header{}
+		for k, v := range m {
+			h.Add(k, v)
+		}
+		d.md.header = h
+	}
+
 	return
 }

--- a/internal/util/pht/client.go
+++ b/internal/util/pht/client.go
@@ -21,6 +21,7 @@ type Client struct {
 	PushPath      string
 	PullPath      string
 	TLSEnabled    bool
+	Header        http.Header
 	Logger        logger.Logger
 }
 
@@ -43,6 +44,7 @@ func (c *Client) Dial(ctx context.Context, addr string) (net.Conn, error) {
 
 	cn := &clientConn{
 		client:     c.Client,
+		header:     c.Header,
 		rxc:        make(chan []byte, 128),
 		closed:     make(chan struct{}),
 		localAddr:  &net.TCPAddr{},
@@ -72,6 +74,15 @@ func (c *Client) authorize(ctx context.Context, addr string) (token string, err 
 	r, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return
+	}
+
+	// Inject custom headers
+	if c.Header != nil {
+		for k, values := range c.Header {
+			for _, v := range values {
+				r.Header.Add(k, v)
+			}
+		}
 	}
 
 	if c.Logger.IsLevelEnabled(logger.TraceLevel) {

--- a/internal/util/pht/conn.go
+++ b/internal/util/pht/conn.go
@@ -17,6 +17,7 @@ import (
 
 type clientConn struct {
 	client     *http.Client
+	header     http.Header
 	pushURL    string
 	pullURL    string
 	buf        []byte
@@ -69,6 +70,15 @@ func (c *clientConn) write(b []byte) (n int, err error) {
 		return
 	}
 
+	// Add custom headers
+	if c.header != nil {
+		for k, values := range c.header {
+			for _, v := range values {
+				req.Header.Add(k, v)
+			}
+		}
+	}
+
 	if c.logger.IsLevelEnabled(logger.TraceLevel) {
 		dump, _ := httputil.DumpRequest(req, false)
 		c.logger.Trace(string(dump))
@@ -107,6 +117,15 @@ func (c *clientConn) readLoop() {
 			r, err := http.NewRequest(http.MethodGet, c.pullURL, nil)
 			if err != nil {
 				return err
+			}
+
+			// Add custom headers
+			if c.header != nil {
+				for k, values := range c.header {
+					for _, v := range values {
+						r.Header.Add(k, v)
+					}
+				}
 			}
 
 			if c.logger.IsLevelEnabled(logger.TraceLevel) {


### PR DESCRIPTION
This PR adds support for custom HTTP headers in the PHT protocol, enabling usage with header-based authentication systems like Cloudflare Access.

## Changes
- Add Header field to PHT Client and clientConn structs
- Support custom headers in authorize, push, and pull requests  
- Add metadata parsing for header configuration as map[string]string
- Enables PHT usage with header-based authentication (e.g., Cloudflare Access)

## Testing
Tested with Cloudflare Access service tokens - successfully authenticates and proxies traffic.

Backwards compatible - headers are optional.