### PR TITLE
feat: support ClientID in Hash strategy for sticky sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # The extended (may be experimental) features outside the main gost tree.
+
+

--- a/selector/strategy.go
+++ b/selector/strategy.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	
 
 	"github.com/go-gost/core/logger"
 	"github.com/go-gost/core/metadata"
@@ -102,6 +103,15 @@ func (s *hashStrategy[T]) Apply(ctx context.Context, vs ...T) (v T) {
 	if len(vs) == 0 {
 		return
 	}
+
+	// 打印 基于用户 id 进行 hash  选择最终出口
+	if clientID := xctx.ClientIDFromContext(ctx); clientID != "" {
+		idStr := string(clientID)
+		value := uint64(crc32.ChecksumIEEE([]byte(idStr)))
+		logger.Default().Infof("【命中】从 xctx 拿到 ID: %s, Hash: %d", idStr, value)
+		return vs[value%uint64(len(vs))]
+	}
+
 	if h := xctx.HashFromContext(ctx); h != nil {
 		value := uint64(crc32.ChecksumIEEE([]byte(h.Source)))
 		logger.Default().Tracef("hash %s %d", h.Source, value)


### PR DESCRIPTION
### Description
Currently, the Hash strategy only uses the remote address for hashing. This PR adds support for retrieving `ClientID` from the context (via `xctx`), allowing consistent node selection based on authenticated user IDs (e.g., SOCKS5 authentication).

### Why this is needed
In scenarios where multiple users connect from the same IP (NAT), the current hash strategy assigns them to the same node. By using `ClientID`, we can achieve true per-user sticky sessions.

### Key Changes
- Modified `selector/strategy/hash.go` to check for `ClientID` in the context before falling back to the remote address.