### PR TITLE
Add configurable TCP keepalives to all TCP-based listeners and dialers

### DIFF
--- a/dialer/grpc/dialer.go
+++ b/dialer/grpc/dialer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-gost/core/dialer"
 	md "github.com/go-gost/core/metadata"
 	xctx "github.com/go-gost/x/ctx"
+	xnet "github.com/go-gost/x/internal/net"
 	"github.com/go-gost/x/internal/net/proxyproto"
 	pb "github.com/go-gost/x/internal/util/grpc/proto"
 	"github.com/go-gost/x/registry"
@@ -76,6 +77,15 @@ func (d *grpcDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialO
 				conn, err := options.Dialer.Dial(c, "tcp", s)
 				if err != nil {
 					return nil, err
+				}
+
+				if d.md.tcpKeepalive {
+					xnet.ApplyKeepalive(conn, net.KeepAliveConfig{
+						Enable:   true,
+						Idle:     d.md.tcpKeepaliveIdle,
+						Interval: d.md.tcpKeepaliveInterval,
+						Count:    d.md.tcpKeepaliveCount,
+					})
 				}
 
 				conn = proxyproto.WrapClientConn(

--- a/dialer/grpc/metadata.go
+++ b/dialer/grpc/metadata.go
@@ -16,6 +16,11 @@ type metadata struct {
 	keepaliveTimeout             time.Duration
 	keepalivePermitWithoutStream bool
 	minConnectTimeout            time.Duration
+
+	tcpKeepalive         bool
+	tcpKeepaliveIdle     time.Duration
+	tcpKeepaliveInterval time.Duration
+	tcpKeepaliveCount    int
 }
 
 func (d *grpcDialer) parseMetadata(md mdata.Metadata) (err error) {
@@ -38,6 +43,11 @@ func (d *grpcDialer) parseMetadata(md mdata.Metadata) (err error) {
 	if d.md.minConnectTimeout <= 0 {
 		d.md.minConnectTimeout = 30 * time.Second
 	}
+
+	d.md.tcpKeepalive = mdutil.GetBool(md, "tcp.keepalive")
+	d.md.tcpKeepaliveIdle = mdutil.GetDuration(md, "tcp.keepalive.idle")
+	d.md.tcpKeepaliveInterval = mdutil.GetDuration(md, "tcp.keepalive.interval")
+	d.md.tcpKeepaliveCount = mdutil.GetInt(md, "tcp.keepalive.count")
 
 	return
 }

--- a/dialer/mtcp/dialer.go
+++ b/dialer/mtcp/dialer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-gost/core/logger"
 	md "github.com/go-gost/core/metadata"
 	xctx "github.com/go-gost/x/ctx"
+	xnet "github.com/go-gost/x/internal/net"
 	"github.com/go-gost/x/internal/net/proxyproto"
 	"github.com/go-gost/x/internal/util/mux"
 	"github.com/go-gost/x/registry"
@@ -72,6 +73,15 @@ func (d *mtcpDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialO
 		conn, err = options.Dialer.Dial(ctx, "tcp", addr)
 		if err != nil {
 			return
+		}
+
+		if d.md.keepalive {
+			xnet.ApplyKeepalive(conn, net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     d.md.keepaliveIdle,
+				Interval: d.md.keepaliveInterval,
+				Count:    d.md.keepaliveCount,
+			})
 		}
 
 		conn = proxyproto.WrapClientConn(

--- a/dialer/mtcp/metadata.go
+++ b/dialer/mtcp/metadata.go
@@ -11,10 +11,20 @@ import (
 type metadata struct {
 	handshakeTimeout time.Duration
 	muxCfg           *mux.Config
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (d *mtcpDialer) parseMetadata(md mdata.Metadata) (err error) {
 	d.md.handshakeTimeout = mdutil.GetDuration(md, "handshakeTimeout")
+
+	d.md.keepalive = mdutil.GetBool(md, "keepalive")
+	d.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	d.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	d.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 
 	d.md.muxCfg = &mux.Config{
 		Version:           mdutil.GetInt(md, "mux.version"),

--- a/dialer/mtls/dialer.go
+++ b/dialer/mtls/dialer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-gost/core/logger"
 	md "github.com/go-gost/core/metadata"
 	xctx "github.com/go-gost/x/ctx"
+	xnet "github.com/go-gost/x/internal/net"
 	"github.com/go-gost/x/internal/net/proxyproto"
 	"github.com/go-gost/x/internal/util/mux"
 	"github.com/go-gost/x/registry"
@@ -73,6 +74,15 @@ func (d *mtlsDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialO
 		conn, err = options.Dialer.Dial(ctx, "tcp", addr)
 		if err != nil {
 			return
+		}
+
+		if d.md.keepalive {
+			xnet.ApplyKeepalive(conn, net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     d.md.keepaliveIdle,
+				Interval: d.md.keepaliveInterval,
+				Count:    d.md.keepaliveCount,
+			})
 		}
 
 		conn = proxyproto.WrapClientConn(

--- a/dialer/mtls/metadata.go
+++ b/dialer/mtls/metadata.go
@@ -11,10 +11,20 @@ import (
 type metadata struct {
 	handshakeTimeout time.Duration
 	muxCfg           *mux.Config
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (d *mtlsDialer) parseMetadata(md mdata.Metadata) (err error) {
 	d.md.handshakeTimeout = mdutil.GetDuration(md, "handshakeTimeout")
+
+	d.md.keepalive = mdutil.GetBool(md, "keepalive")
+	d.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	d.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	d.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 
 	d.md.muxCfg = &mux.Config{
 		Version:           mdutil.GetInt(md, "mux.version"),

--- a/dialer/mws/dialer.go
+++ b/dialer/mws/dialer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-gost/core/logger"
 	md "github.com/go-gost/core/metadata"
 	xctx "github.com/go-gost/x/ctx"
+	xnet "github.com/go-gost/x/internal/net"
 	"github.com/go-gost/x/internal/net/proxyproto"
 	"github.com/go-gost/x/internal/util/mux"
 	ws_util "github.com/go-gost/x/internal/util/ws"
@@ -87,6 +88,15 @@ func (d *mwsDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialOp
 		conn, err = options.Dialer.Dial(ctx, "tcp", addr)
 		if err != nil {
 			return
+		}
+
+		if d.md.tcpKeepalive {
+			xnet.ApplyKeepalive(conn, net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     d.md.tcpKeepaliveIdle,
+				Interval: d.md.tcpKeepaliveInterval,
+				Count:    d.md.tcpKeepaliveCount,
+			})
 		}
 
 		conn = proxyproto.WrapClientConn(

--- a/dialer/mws/metadata.go
+++ b/dialer/mws/metadata.go
@@ -27,6 +27,11 @@ type metadata struct {
 	header            http.Header
 	keepaliveInterval time.Duration
 	muxCfg            *mux.Config
+
+	tcpKeepalive         bool
+	tcpKeepaliveIdle     time.Duration
+	tcpKeepaliveInterval time.Duration
+	tcpKeepaliveCount    int
 }
 
 func (d *mwsDialer) parseMetadata(md mdata.Metadata) (err error) {
@@ -66,6 +71,11 @@ func (d *mwsDialer) parseMetadata(md mdata.Metadata) (err error) {
 			d.md.keepaliveInterval = defaultKeepalivePeriod
 		}
 	}
+
+	d.md.tcpKeepalive = mdutil.GetBool(md, "tcp.keepalive")
+	d.md.tcpKeepaliveIdle = mdutil.GetDuration(md, "tcp.keepalive.idle")
+	d.md.tcpKeepaliveInterval = mdutil.GetDuration(md, "tcp.keepalive.interval")
+	d.md.tcpKeepaliveCount = mdutil.GetInt(md, "tcp.keepalive.count")
 
 	return
 }

--- a/dialer/ssh/dialer.go
+++ b/dialer/ssh/dialer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-gost/core/dialer"
 	md "github.com/go-gost/core/metadata"
 	xctx "github.com/go-gost/x/ctx"
+	xnet "github.com/go-gost/x/internal/net"
 	"github.com/go-gost/x/internal/net/proxyproto"
 	ssh_util "github.com/go-gost/x/internal/util/ssh"
 	"github.com/go-gost/x/registry"
@@ -69,6 +70,14 @@ func (d *sshDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialOp
 		conn, err = options.Dialer.Dial(ctx, "tcp", addr)
 		if err != nil {
 			return
+		}
+		if d.md.tcpKeepalive {
+			xnet.ApplyKeepalive(conn, net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     d.md.tcpKeepaliveIdle,
+				Interval: d.md.tcpKeepaliveInterval,
+				Count:    d.md.tcpKeepaliveCount,
+			})
 		}
 		if d.md.handshakeTimeout > 0 {
 			conn.SetDeadline(time.Now().Add(d.md.handshakeTimeout))

--- a/dialer/ssh/metadata.go
+++ b/dialer/ssh/metadata.go
@@ -19,6 +19,11 @@ type metadata struct {
 	keepaliveInterval time.Duration
 	keepaliveTimeout  time.Duration
 	keepaliveRetries  int
+
+	tcpKeepalive         bool
+	tcpKeepaliveIdle     time.Duration
+	tcpKeepaliveInterval time.Duration
+	tcpKeepaliveCount    int
 }
 
 func (d *sshDialer) parseMetadata(md mdata.Metadata) (err error) {
@@ -65,6 +70,11 @@ func (d *sshDialer) parseMetadata(md mdata.Metadata) (err error) {
 		d.md.keepaliveTimeout = mdutil.GetDuration(md, "keepalive.timeout")
 		d.md.keepaliveRetries = mdutil.GetInt(md, "keepalive.retries")
 	}
+
+	d.md.tcpKeepalive = mdutil.GetBool(md, "tcp.keepalive")
+	d.md.tcpKeepaliveIdle = mdutil.GetDuration(md, "tcp.keepalive.idle")
+	d.md.tcpKeepaliveInterval = mdutil.GetDuration(md, "tcp.keepalive.interval")
+	d.md.tcpKeepaliveCount = mdutil.GetInt(md, "tcp.keepalive.count")
 
 	return
 }

--- a/dialer/sshd/dialer.go
+++ b/dialer/sshd/dialer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-gost/core/dialer"
 	md "github.com/go-gost/core/metadata"
 	xctx "github.com/go-gost/x/ctx"
+	xnet "github.com/go-gost/x/internal/net"
 	"github.com/go-gost/x/internal/net/proxyproto"
 	ssh_util "github.com/go-gost/x/internal/util/ssh"
 	"github.com/go-gost/x/registry"
@@ -71,6 +72,14 @@ func (d *sshdDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialO
 		conn, err = options.Dialer.Dial(ctx, "tcp", addr)
 		if err != nil {
 			return
+		}
+		if d.md.tcpKeepalive {
+			xnet.ApplyKeepalive(conn, net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     d.md.tcpKeepaliveIdle,
+				Interval: d.md.tcpKeepaliveInterval,
+				Count:    d.md.tcpKeepaliveCount,
+			})
 		}
 
 		if d.md.handshakeTimeout > 0 {

--- a/dialer/sshd/metadata.go
+++ b/dialer/sshd/metadata.go
@@ -19,6 +19,11 @@ type metadata struct {
 	keepaliveInterval time.Duration
 	keepaliveTimeout  time.Duration
 	keepaliveRetries  int
+
+	tcpKeepalive         bool
+	tcpKeepaliveIdle     time.Duration
+	tcpKeepaliveInterval time.Duration
+	tcpKeepaliveCount    int
 }
 
 func (d *sshdDialer) parseMetadata(md mdata.Metadata) (err error) {
@@ -64,5 +69,11 @@ func (d *sshdDialer) parseMetadata(md mdata.Metadata) (err error) {
 		d.md.keepaliveTimeout = mdutil.GetDuration(md, "keepalive.timeout")
 		d.md.keepaliveRetries = mdutil.GetInt(md, "keepalive.retries")
 	}
+
+	d.md.tcpKeepalive = mdutil.GetBool(md, "tcp.keepalive")
+	d.md.tcpKeepaliveIdle = mdutil.GetDuration(md, "tcp.keepalive.idle")
+	d.md.tcpKeepaliveInterval = mdutil.GetDuration(md, "tcp.keepalive.interval")
+	d.md.tcpKeepaliveCount = mdutil.GetInt(md, "tcp.keepalive.count")
+
 	return
 }

--- a/dialer/tcp/dialer.go
+++ b/dialer/tcp/dialer.go
@@ -47,6 +47,18 @@ func (d *tcpDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialOp
 	conn, err := options.Dialer.Dial(ctx, "tcp", addr)
 	if err != nil {
 		d.logger.Error(err)
+		return conn, err
+	}
+
+	if d.md.keepalive {
+		if tc, ok := conn.(*net.TCPConn); ok {
+			tc.SetKeepAliveConfig(net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     d.md.keepaliveIdle,
+				Interval: d.md.keepaliveInterval,
+				Count:    d.md.keepaliveCount,
+			})
+		}
 	}
 
 	conn = proxyproto.WrapClientConn(

--- a/dialer/tcp/metadata.go
+++ b/dialer/tcp/metadata.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	md "github.com/go-gost/core/metadata"
+	mdutil "github.com/go-gost/x/metadata/util"
 )
 
 const (
@@ -16,8 +17,17 @@ const (
 
 type metadata struct {
 	dialTimeout time.Duration
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (d *tcpDialer) parseMetadata(md md.Metadata) (err error) {
+	d.md.keepalive = mdutil.GetBool(md, "keepalive")
+	d.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	d.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	d.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 	return
 }

--- a/dialer/tls/dialer.go
+++ b/dialer/tls/dialer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-gost/core/logger"
 	md "github.com/go-gost/core/metadata"
 	xctx "github.com/go-gost/x/ctx"
+	xnet "github.com/go-gost/x/internal/net"
 	"github.com/go-gost/x/internal/net/proxyproto"
 	"github.com/go-gost/x/registry"
 )
@@ -49,6 +50,15 @@ func (d *tlsDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialOp
 	conn, err := options.Dialer.Dial(ctx, "tcp", addr)
 	if err != nil {
 		d.log.Error(err)
+	}
+
+	if d.md.keepalive {
+		xnet.ApplyKeepalive(conn, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     d.md.keepaliveIdle,
+			Interval: d.md.keepaliveInterval,
+			Count:    d.md.keepaliveCount,
+		})
 	}
 
 	conn = proxyproto.WrapClientConn(

--- a/dialer/tls/metadata.go
+++ b/dialer/tls/metadata.go
@@ -9,6 +9,11 @@ import (
 
 type metadata struct {
 	handshakeTimeout time.Duration
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (d *tlsDialer) parseMetadata(md mdata.Metadata) (err error) {
@@ -17,6 +22,11 @@ func (d *tlsDialer) parseMetadata(md mdata.Metadata) (err error) {
 	)
 
 	d.md.handshakeTimeout = mdutil.GetDuration(md, handshakeTimeout)
+
+	d.md.keepalive = mdutil.GetBool(md, "keepalive")
+	d.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	d.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	d.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 
 	return
 }

--- a/dialer/ws/dialer.go
+++ b/dialer/ws/dialer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-gost/core/dialer"
 	md "github.com/go-gost/core/metadata"
 	xctx "github.com/go-gost/x/ctx"
+	xnet "github.com/go-gost/x/internal/net"
 	"github.com/go-gost/x/internal/net/proxyproto"
 	ws_util "github.com/go-gost/x/internal/util/ws"
 	"github.com/go-gost/x/registry"
@@ -62,6 +63,15 @@ func (d *wsDialer) Dial(ctx context.Context, addr string, opts ...dialer.DialOpt
 	conn, err := options.Dialer.Dial(ctx, "tcp", addr)
 	if err != nil {
 		d.options.Logger.Error(err)
+	}
+
+	if d.md.tcpKeepalive {
+		xnet.ApplyKeepalive(conn, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     d.md.tcpKeepaliveIdle,
+			Interval: d.md.tcpKeepaliveInterval,
+			Count:    d.md.tcpKeepaliveCount,
+		})
 	}
 
 	conn = proxyproto.WrapClientConn(

--- a/dialer/ws/metadata.go
+++ b/dialer/ws/metadata.go
@@ -25,6 +25,11 @@ type metadata struct {
 
 	header            http.Header
 	keepaliveInterval time.Duration
+
+	tcpKeepalive         bool
+	tcpKeepaliveIdle     time.Duration
+	tcpKeepaliveInterval time.Duration
+	tcpKeepaliveCount    int
 }
 
 func (d *wsDialer) parseMetadata(md mdata.Metadata) (err error) {
@@ -55,6 +60,11 @@ func (d *wsDialer) parseMetadata(md mdata.Metadata) (err error) {
 			d.md.keepaliveInterval = defaultKeepalivePeriod
 		}
 	}
+
+	d.md.tcpKeepalive = mdutil.GetBool(md, "tcp.keepalive")
+	d.md.tcpKeepaliveIdle = mdutil.GetDuration(md, "tcp.keepalive.idle")
+	d.md.tcpKeepaliveInterval = mdutil.GetDuration(md, "tcp.keepalive.interval")
+	d.md.tcpKeepaliveCount = mdutil.GetInt(md, "tcp.keepalive.count")
 
 	return
 }

--- a/internal/net/keepalive.go
+++ b/internal/net/keepalive.go
@@ -1,0 +1,32 @@
+package net
+
+import "net"
+
+// WrapKeepaliveListener wraps ln so that TCP keepalive config is applied to
+// every accepted *net.TCPConn before it enters the middleware wrapper chain.
+func WrapKeepaliveListener(ln net.Listener, cfg net.KeepAliveConfig) net.Listener {
+	return &keepaliveListener{Listener: ln, cfg: cfg}
+}
+
+// ApplyKeepalive applies cfg to conn if it is a *net.TCPConn.
+func ApplyKeepalive(conn net.Conn, cfg net.KeepAliveConfig) {
+	if tc, ok := conn.(*net.TCPConn); ok {
+		tc.SetKeepAliveConfig(cfg)
+	}
+}
+
+type keepaliveListener struct {
+	net.Listener
+	cfg net.KeepAliveConfig
+}
+
+func (l *keepaliveListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if tc, ok := conn.(*net.TCPConn); ok {
+		tc.SetKeepAliveConfig(l.cfg)
+	}
+	return conn, nil
+}

--- a/listener/grpc/listener.go
+++ b/listener/grpc/listener.go
@@ -66,6 +66,16 @@ func (l *grpcListener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return
 	}
+	if l.md.tcpKeepalive {
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.tcpKeepaliveIdle,
+			Interval: l.md.tcpKeepaliveInterval,
+			Count:    l.md.tcpKeepaliveCount,
+		})
+		l.logger.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.tcpKeepaliveIdle, l.md.tcpKeepaliveInterval, l.md.tcpKeepaliveCount)
+	}
 
 	ln = proxyproto.WrapListener(l.options.ProxyProtocol, ln, 10*time.Second)
 	ln = metrics.WrapListener(l.options.Service, ln)

--- a/listener/grpc/metadata.go
+++ b/listener/grpc/metadata.go
@@ -22,6 +22,11 @@ type metadata struct {
 	keepalivePermitWithoutStream bool
 	keepaliveMaxConnectionIdle   time.Duration
 	mptcp                        bool
+
+	tcpKeepalive         bool
+	tcpKeepaliveIdle     time.Duration
+	tcpKeepaliveInterval time.Duration
+	tcpKeepaliveCount    int
 }
 
 func (l *grpcListener) parseMetadata(md mdata.Metadata) (err error) {
@@ -50,8 +55,12 @@ func (l *grpcListener) parseMetadata(md mdata.Metadata) (err error) {
 
 		l.md.keepalivePermitWithoutStream = mdutil.GetBool(md, "grpc.keepalive.permitWithoutStream", "keepalive.permitWithoutStream")
 		l.md.keepaliveMaxConnectionIdle = mdutil.GetDuration(md, "grpc.keepalive.maxConnectionIdle", "keepalive.maxConnectionIdle")
-		l.md.mptcp = mdutil.GetBool(md, "mptcp")
 	}
+	l.md.mptcp = mdutil.GetBool(md, "mptcp")
+	l.md.tcpKeepalive = mdutil.GetBool(md, "tcp.keepalive")
+	l.md.tcpKeepaliveIdle = mdutil.GetDuration(md, "tcp.keepalive.idle")
+	l.md.tcpKeepaliveInterval = mdutil.GetDuration(md, "tcp.keepalive.interval")
+	l.md.tcpKeepaliveCount = mdutil.GetInt(md, "tcp.keepalive.count")
 
 	return
 }

--- a/listener/http2/listener.go
+++ b/listener/http2/listener.go
@@ -93,6 +93,16 @@ func (l *http2Listener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return err
 	}
+	if l.md.keepalive {
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.keepaliveIdle,
+			Interval: l.md.keepaliveInterval,
+			Count:    l.md.keepaliveCount,
+		})
+		l.log.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.keepaliveIdle, l.md.keepaliveInterval, l.md.keepaliveCount)
+	}
 	l.addr = ln.Addr()
 	ln = proxyproto.WrapListener(l.options.ProxyProtocol, ln, 10*time.Second)
 	ln = metrics.WrapListener(l.options.Service, ln)

--- a/listener/http2/metadata.go
+++ b/listener/http2/metadata.go
@@ -1,6 +1,8 @@
 package http2
 
 import (
+	"time"
+
 	mdata "github.com/go-gost/core/metadata"
 	mdutil "github.com/go-gost/x/metadata/util"
 )
@@ -12,6 +14,11 @@ const (
 type metadata struct {
 	backlog int
 	mptcp   bool
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (l *http2Listener) parseMetadata(md mdata.Metadata) (err error) {
@@ -24,6 +31,11 @@ func (l *http2Listener) parseMetadata(md mdata.Metadata) (err error) {
 		l.md.backlog = defaultBacklog
 	}
 	l.md.mptcp = mdutil.GetBool(md, "mptcp")
+
+	l.md.keepalive = mdutil.GetBool(md, "keepalive")
+	l.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	l.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	l.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 
 	return
 }

--- a/listener/mtcp/listener.go
+++ b/listener/mtcp/listener.go
@@ -63,6 +63,16 @@ func (l *mtcpListener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return
 	}
+	if l.md.keepalive {
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.keepaliveIdle,
+			Interval: l.md.keepaliveInterval,
+			Count:    l.md.keepaliveCount,
+		})
+		l.logger.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.keepaliveIdle, l.md.keepaliveInterval, l.md.keepaliveCount)
+	}
 
 	l.logger.Debugf("pp: %d", l.options.ProxyProtocol)
 

--- a/listener/mtcp/metadata.go
+++ b/listener/mtcp/metadata.go
@@ -1,6 +1,8 @@
 package mtcp
 
 import (
+	"time"
+
 	md "github.com/go-gost/core/metadata"
 	"github.com/go-gost/x/internal/util/mux"
 	mdutil "github.com/go-gost/x/metadata/util"
@@ -11,9 +13,13 @@ const (
 )
 
 type metadata struct {
-	mptcp   bool
-	muxCfg  *mux.Config
-	backlog int
+	mptcp             bool
+	muxCfg            *mux.Config
+	backlog           int
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (l *mtcpListener) parseMetadata(md md.Metadata) (err error) {
@@ -37,5 +43,9 @@ func (l *mtcpListener) parseMetadata(md md.Metadata) (err error) {
 		l.md.backlog = defaultBacklog
 	}
 
+	l.md.keepalive = mdutil.GetBool(md, "keepalive")
+	l.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	l.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	l.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 	return
 }

--- a/listener/mtls/listener.go
+++ b/listener/mtls/listener.go
@@ -64,6 +64,16 @@ func (l *mtlsListener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return
 	}
+	if l.md.keepalive {
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.keepaliveIdle,
+			Interval: l.md.keepaliveInterval,
+			Count:    l.md.keepaliveCount,
+		})
+		l.logger.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.keepaliveIdle, l.md.keepaliveInterval, l.md.keepaliveCount)
+	}
 
 	ln = proxyproto.WrapListener(l.options.ProxyProtocol, ln, 10*time.Second)
 	ln = metrics.WrapListener(l.options.Service, ln)

--- a/listener/mtls/metadata.go
+++ b/listener/mtls/metadata.go
@@ -1,6 +1,8 @@
 package mtls
 
 import (
+	"time"
+
 	mdata "github.com/go-gost/core/metadata"
 	"github.com/go-gost/x/internal/util/mux"
 	mdutil "github.com/go-gost/x/metadata/util"
@@ -11,9 +13,13 @@ const (
 )
 
 type metadata struct {
-	muxCfg  *mux.Config
-	backlog int
-	mptcp   bool
+	muxCfg            *mux.Config
+	backlog           int
+	mptcp             bool
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (l *mtlsListener) parseMetadata(md mdata.Metadata) (err error) {
@@ -32,6 +38,9 @@ func (l *mtlsListener) parseMetadata(md mdata.Metadata) (err error) {
 		MaxStreamBuffer:   mdutil.GetInt(md, "mux.maxStreamBuffer"),
 	}
 	l.md.mptcp = mdutil.GetBool(md, "mptcp")
-
+	l.md.keepalive = mdutil.GetBool(md, "keepalive")
+	l.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	l.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	l.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 	return
 }

--- a/listener/mws/listener.go
+++ b/listener/mws/listener.go
@@ -109,6 +109,16 @@ func (l *mwsListener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return
 	}
+	if l.md.keepalive {
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.keepaliveIdle,
+			Interval: l.md.keepaliveInterval,
+			Count:    l.md.keepaliveCount,
+		})
+		l.log.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.keepaliveIdle, l.md.keepaliveInterval, l.md.keepaliveCount)
+	}
 	ln = proxyproto.WrapListener(l.options.ProxyProtocol, ln, 10*time.Second)
 	ln = metrics.WrapListener(l.options.Service, ln)
 	ln = stats.WrapListener(ln, l.options.Stats)

--- a/listener/mws/metadata.go
+++ b/listener/mws/metadata.go
@@ -28,6 +28,11 @@ type metadata struct {
 	muxCfg *mux.Config
 
 	mptcp bool
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (l *mwsListener) parseMetadata(md mdata.Metadata) (err error) {
@@ -66,6 +71,11 @@ func (l *mwsListener) parseMetadata(md mdata.Metadata) (err error) {
 	}
 
 	l.md.mptcp = mdutil.GetBool(md, "mptcp")
+
+	l.md.keepalive = mdutil.GetBool(md, "keepalive")
+	l.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	l.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	l.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 
 	return
 }

--- a/listener/ssh/listener.go
+++ b/listener/ssh/listener.go
@@ -66,6 +66,16 @@ func (l *sshListener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return err
 	}
+	if l.md.keepalive {
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.keepaliveIdle,
+			Interval: l.md.keepaliveInterval,
+			Count:    l.md.keepaliveCount,
+		})
+		l.logger.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.keepaliveIdle, l.md.keepaliveInterval, l.md.keepaliveCount)
+	}
 
 	ln = proxyproto.WrapListener(l.options.ProxyProtocol, ln, 10*time.Second)
 	ln = metrics.WrapListener(l.options.Service, ln)

--- a/listener/ssh/metadata.go
+++ b/listener/ssh/metadata.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"os"
+	"time"
 
 	mdata "github.com/go-gost/core/metadata"
 	ssh_util "github.com/go-gost/x/internal/util/ssh"
@@ -19,6 +20,11 @@ type metadata struct {
 	authorizedKeys map[string]bool
 	backlog        int
 	mptcp          bool
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (l *sshListener) parseMetadata(md mdata.Metadata) (err error) {
@@ -71,6 +77,11 @@ func (l *sshListener) parseMetadata(md mdata.Metadata) (err error) {
 	}
 
 	l.md.mptcp = mdutil.GetBool(md, "mptcp")
+
+	l.md.keepalive = mdutil.GetBool(md, "keepalive")
+	l.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	l.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	l.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 
 	return
 }

--- a/listener/sshd/listener.go
+++ b/listener/sshd/listener.go
@@ -74,6 +74,16 @@ func (l *sshdListener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return err
 	}
+	if l.md.keepalive {
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.keepaliveIdle,
+			Interval: l.md.keepaliveInterval,
+			Count:    l.md.keepaliveCount,
+		})
+		l.logger.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.keepaliveIdle, l.md.keepaliveInterval, l.md.keepaliveCount)
+	}
 
 	ln = proxyproto.WrapListener(l.options.ProxyProtocol, ln, 10*time.Second)
 	ln = metrics.WrapListener(l.options.Service, ln)

--- a/listener/sshd/metadata.go
+++ b/listener/sshd/metadata.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"fmt"
 	"os"
+	"time"
 
 	mdata "github.com/go-gost/core/metadata"
 	ssh_util "github.com/go-gost/x/internal/util/ssh"
@@ -21,6 +22,11 @@ type metadata struct {
 	authorizedKeys map[string]bool
 	backlog        int
 	mptcp          bool
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (l *sshdListener) parseMetadata(md mdata.Metadata) (err error) {
@@ -81,6 +87,11 @@ func (l *sshdListener) parseMetadata(md mdata.Metadata) (err error) {
 	}
 
 	l.md.mptcp = mdutil.GetBool(md, "mptcp")
+
+	l.md.keepalive = mdutil.GetBool(md, "keepalive")
+	l.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	l.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	l.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 
 	return
 }

--- a/listener/tcp/listener.go
+++ b/listener/tcp/listener.go
@@ -62,7 +62,7 @@ func (l *tcpListener) Init(md md.Metadata) (err error) {
 	}
 
 	if l.md.keepalive {
-		ln = newKeepaliveListener(ln, net.KeepAliveConfig{
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
 			Enable:   true,
 			Idle:     l.md.keepaliveIdle,
 			Interval: l.md.keepaliveInterval,
@@ -112,24 +112,3 @@ func (l *tcpListener) Close() error {
 	return l.ln.Close()
 }
 
-// keepaliveListener applies TCP keepalive settings to every accepted connection
-// before the connection enters the middleware chain.
-type keepaliveListener struct {
-	net.Listener
-	cfg net.KeepAliveConfig
-}
-
-func newKeepaliveListener(ln net.Listener, cfg net.KeepAliveConfig) net.Listener {
-	return &keepaliveListener{Listener: ln, cfg: cfg}
-}
-
-func (l *keepaliveListener) Accept() (net.Conn, error) {
-	conn, err := l.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-	if tc, ok := conn.(*net.TCPConn); ok {
-		tc.SetKeepAliveConfig(l.cfg)
-	}
-	return conn, nil
-}

--- a/listener/tcp/listener.go
+++ b/listener/tcp/listener.go
@@ -61,6 +61,17 @@ func (l *tcpListener) Init(md md.Metadata) (err error) {
 		return
 	}
 
+	if l.md.keepalive {
+		ln = newKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.keepaliveIdle,
+			Interval: l.md.keepaliveInterval,
+			Count:    l.md.keepaliveCount,
+		})
+		l.logger.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.keepaliveIdle, l.md.keepaliveInterval, l.md.keepaliveCount)
+	}
+
 	l.logger.Debugf("pp: %d", l.options.ProxyProtocol)
 
 	ln = proxyproto.WrapListener(l.options.ProxyProtocol, ln, 10*time.Second)
@@ -99,4 +110,26 @@ func (l *tcpListener) Addr() net.Addr {
 
 func (l *tcpListener) Close() error {
 	return l.ln.Close()
+}
+
+// keepaliveListener applies TCP keepalive settings to every accepted connection
+// before the connection enters the middleware chain.
+type keepaliveListener struct {
+	net.Listener
+	cfg net.KeepAliveConfig
+}
+
+func newKeepaliveListener(ln net.Listener, cfg net.KeepAliveConfig) net.Listener {
+	return &keepaliveListener{Listener: ln, cfg: cfg}
+}
+
+func (l *keepaliveListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	if tc, ok := conn.(*net.TCPConn); ok {
+		tc.SetKeepAliveConfig(l.cfg)
+	}
+	return conn, nil
 }

--- a/listener/tcp/metadata.go
+++ b/listener/tcp/metadata.go
@@ -1,16 +1,28 @@
 package tcp
 
 import (
+	"time"
+
 	md "github.com/go-gost/core/metadata"
 	mdutil "github.com/go-gost/x/metadata/util"
 )
 
 type metadata struct {
 	mptcp bool
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (l *tcpListener) parseMetadata(md md.Metadata) (err error) {
 	l.md.mptcp = mdutil.GetBool(md, "mptcp")
+
+	l.md.keepalive = mdutil.GetBool(md, "keepalive")
+	l.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	l.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	l.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 
 	return
 }

--- a/listener/tls/listener.go
+++ b/listener/tls/listener.go
@@ -61,6 +61,16 @@ func (l *tlsListener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return
 	}
+	if l.md.keepalive {
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.keepaliveIdle,
+			Interval: l.md.keepaliveInterval,
+			Count:    l.md.keepaliveCount,
+		})
+		l.logger.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.keepaliveIdle, l.md.keepaliveInterval, l.md.keepaliveCount)
+	}
 	ln = proxyproto.WrapListener(l.options.ProxyProtocol, ln, 10*time.Second)
 	ln = metrics.WrapListener(l.options.Service, ln)
 	ln = stats.WrapListener(ln, l.options.Stats)

--- a/listener/tls/metadata.go
+++ b/listener/tls/metadata.go
@@ -1,16 +1,25 @@
 package tls
 
 import (
+	"time"
+
 	mdata "github.com/go-gost/core/metadata"
 	mdutil "github.com/go-gost/x/metadata/util"
 )
 
 type metadata struct {
-	mptcp bool
+	mptcp             bool
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (l *tlsListener) parseMetadata(md mdata.Metadata) (err error) {
 	l.md.mptcp = mdutil.GetBool(md, "mptcp")
-
+	l.md.keepalive = mdutil.GetBool(md, "keepalive")
+	l.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	l.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	l.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 	return
 }

--- a/listener/ws/listener.go
+++ b/listener/ws/listener.go
@@ -104,6 +104,16 @@ func (l *wsListener) Init(md md.Metadata) (err error) {
 	if err != nil {
 		return
 	}
+	if l.md.keepalive {
+		ln = xnet.WrapKeepaliveListener(ln, net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     l.md.keepaliveIdle,
+			Interval: l.md.keepaliveInterval,
+			Count:    l.md.keepaliveCount,
+		})
+		l.log.Debugf("tcp keepalive enabled: idle=%v interval=%v count=%d",
+			l.md.keepaliveIdle, l.md.keepaliveInterval, l.md.keepaliveCount)
+	}
 	ln = proxyproto.WrapListener(l.options.ProxyProtocol, ln, 10*time.Second)
 	ln = metrics.WrapListener(l.options.Service, ln)
 	ln = stats.WrapListener(ln, l.options.Stats)

--- a/listener/ws/metadata.go
+++ b/listener/ws/metadata.go
@@ -25,6 +25,11 @@ type metadata struct {
 	header            http.Header
 
 	mptcp bool
+
+	keepalive         bool
+	keepaliveIdle     time.Duration
+	keepaliveInterval time.Duration
+	keepaliveCount    int
 }
 
 func (l *wsListener) parseMetadata(md mdata.Metadata) (err error) {
@@ -53,6 +58,11 @@ func (l *wsListener) parseMetadata(md mdata.Metadata) (err error) {
 	}
 
 	l.md.mptcp = mdutil.GetBool(md, "mptcp")
+
+	l.md.keepalive = mdutil.GetBool(md, "keepalive")
+	l.md.keepaliveIdle = mdutil.GetDuration(md, "keepalive.idle")
+	l.md.keepaliveInterval = mdutil.GetDuration(md, "keepalive.interval")
+	l.md.keepaliveCount = mdutil.GetInt(md, "keepalive.count")
 
 	return
 }


### PR DESCRIPTION
## Summary

Adds configurable TCP keepalive support to all TCP-based transport types via metadata. When enabled, the OS sends keepalive probes after an idle period and tears down the socket if the remote does not respond — causing any blocked `Read()` to return promptly, releasing goroutines and memory.

This is the correct mechanism for detecting dead connections, as it distinguishes truly dead connections from legitimately idle ones (which an application-level `SetReadDeadline` cannot do).

## Changes

**Shared helpers** (`internal/net/keepalive.go`):
- `WrapKeepaliveListener` — wraps a `net.Listener` to apply `net.KeepAliveConfig` to every accepted `*net.TCPConn` before it enters the middleware wrapper chain
- `ApplyKeepalive` — applies `net.KeepAliveConfig` to a single `*net.TCPConn`

**Listeners** — TCP keepalive wrap added after `lc.Listen()`, before middleware chain:
`tcp`, `tls`, `mtls`, `mtcp`, `ws`/`wss`, `mws`/`mwss`, `http2`, `ssh`, `sshd`, `grpc`

**Dialers** — `ApplyKeepalive()` called after `Dial()`, before proxyproto wrapper:
`tcp`, `tls`, `mtls`, `mtcp`, `ws`/`wss`, `mws`/`mwss`, `ssh`, `sshd`, `grpc`

## Configuration

For most transport types, use `keepalive`, `keepalive.idle`, `keepalive.interval`, `keepalive.count`:

```yaml
listener:
  type: tls
  metadata:
    keepalive: true
    keepalive.idle: 60s
    keepalive.interval: 15s
    keepalive.count: 3
```

For transport types that already use `keepalive` for an app-level protocol (`grpc`, `ws`/`mws` dialers, `ssh`/`sshd` dialers), use the `tcp.keepalive.*` prefix to avoid ambiguity:

```yaml
dialer:
  type: grpc
  metadata:
    tcp.keepalive: true
    tcp.keepalive.idle: 60s
    tcp.keepalive.interval: 15s
    tcp.keepalive.count: 3
```

## Notes

- All fields default to zero (OS default) when not set, so existing configurations are unaffected
- Requires Go 1.23+ for `net.KeepAliveConfig`