### PR TITLE
feat service: introduce labels for logs/recorder

### DIFF
--- a/config/parsing/parse.go
+++ b/config/parsing/parse.go
@@ -92,4 +92,8 @@ const (
 
 	// MDKeyDialTimeout sets the dial timeout for outbound connections.
 	MDKeyDialTimeout = "dialTimeout"
+
+	// MDKeyLabels holds static key/value labels attached to a service's
+	// records and logs.
+	MDKeyLabels = "labels"
 )

--- a/config/parsing/service/parse.go
+++ b/config/parsing/service/parse.go
@@ -115,6 +115,7 @@ func ParseService(cfg *config.ServiceConfig) (service.Service, error) {
 	var observerPeriod time.Duration
 	var netnsIn, netnsOut string
 	var dialTimeout time.Duration
+	var labels map[string]string
 
 	var limiterRefreshInterval time.Duration
 	var limiterCleanupInterval time.Duration
@@ -150,6 +151,14 @@ func ParseService(cfg *config.ServiceConfig) (service.Service, error) {
 		limiterRefreshInterval = mdutil.GetDuration(md, parsing.MDKeyLimiterRefreshInterval)
 		limiterCleanupInterval = mdutil.GetDuration(md, parsing.MDKeyLimiterCleanupInterval)
 		limiterScope = mdutil.GetString(md, parsing.MDKeyLimiterScope)
+
+		labels = mdutil.GetStringMapString(md, parsing.MDKeyLabels)
+	}
+
+	if len(labels) > 0 {
+		serviceLogger = serviceLogger.WithFields(map[string]any{
+			"labels": labels,
+		})
 	}
 
 	listenerLogger := serviceLogger.WithFields(map[string]any{
@@ -349,6 +358,7 @@ func ParseService(cfg *config.ServiceConfig) (service.Service, error) {
 		xservice.ObserverOption(registry.ObserverRegistry().Get(cfg.Observer)),
 		xservice.ObserverPeriodOption(observerPeriod),
 		xservice.LoggerOption(serviceLogger),
+		xservice.LabelsOption(labels),
 	)
 
 	serviceLogger.Infof("listening on %s/%s", s.Addr().String(), s.Addr().Network())

--- a/ctx/value.go
+++ b/ctx/value.go
@@ -100,3 +100,17 @@ func ClientIDFromContext(ctx context.Context) ClientID {
 	v, _ := ctx.Value(clientIDKey{}).(ClientID)
 	return v
 }
+
+// labelsKey saves the static service labels.
+type labelsKey struct{}
+
+// ContextWithLabels returns a new context carrying the given service labels.
+func ContextWithLabels(ctx context.Context, labels map[string]string) context.Context {
+	return context.WithValue(ctx, labelsKey{}, labels)
+}
+
+// LabelsFromContext returns the service labels stored in the context, or nil.
+func LabelsFromContext(ctx context.Context) map[string]string {
+	v, _ := ctx.Value(labelsKey{}).(map[string]string)
+	return v
+}

--- a/ctx/value_test.go
+++ b/ctx/value_test.go
@@ -3,6 +3,7 @@ package ctx
 import (
 	"context"
 	"net"
+	"reflect"
 	"testing"
 )
 
@@ -146,6 +147,29 @@ func TestClientIDFromContext_WrongType(t *testing.T) {
 	ctx := context.WithValue(context.Background(), clientIDKey{}, 99)
 	if got := ClientIDFromContext(ctx); got != "" {
 		t.Errorf("ClientIDFromContext(wrong type) = %q, want empty string", got)
+	}
+}
+
+func TestContextWithLabels(t *testing.T) {
+	labels := map[string]string{"tenant": "acme", "region": "eu"}
+	ctx := ContextWithLabels(context.Background(), labels)
+
+	got := LabelsFromContext(ctx)
+	if !reflect.DeepEqual(got, labels) {
+		t.Errorf("LabelsFromContext() = %v, want %v", got, labels)
+	}
+}
+
+func TestLabelsFromContext_Empty(t *testing.T) {
+	if got := LabelsFromContext(context.Background()); got != nil {
+		t.Errorf("LabelsFromContext(empty) = %v, want nil", got)
+	}
+}
+
+func TestLabelsFromContext_WrongType(t *testing.T) {
+	ctx := context.WithValue(context.Background(), labelsKey{}, "not-a-map")
+	if got := LabelsFromContext(ctx); got != nil {
+		t.Errorf("LabelsFromContext(wrong type) = %v, want nil", got)
 	}
 }
 

--- a/recorder/recorder.go
+++ b/recorder/recorder.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-gost/core/recorder"
+	xctx "github.com/go-gost/x/ctx"
 )
 
 const (
@@ -82,16 +83,17 @@ type DNSRecorderObject struct {
 // level — addresses, protocols, transferred bytes, and optional sub-records
 // for HTTP, WebSocket, TLS, and DNS traffic.
 type HandlerRecorderObject struct {
-	Node       string `json:"node,omitempty"`
-	Service    string `json:"service"`
-	Network    string `json:"network"`
-	RemoteAddr string `json:"remote"`
-	LocalAddr  string `json:"local"`
-	ClientAddr string `json:"client"`
-	SrcAddr    string `json:"src"`
-	DstAddr    string `json:"dst"`
-	Host       string `json:"host"`
-	Proto      string `json:"proto,omitempty"`
+	Node        string                   `json:"node,omitempty"`
+	Service     string                   `json:"service"`
+	Labels      map[string]string        `json:"labels,omitempty"`
+	Network     string                   `json:"network"`
+	RemoteAddr  string                   `json:"remote"`
+	LocalAddr   string                   `json:"local"`
+	ClientAddr  string                   `json:"client"`
+	SrcAddr     string                   `json:"src"`
+	DstAddr     string                   `json:"dst"`
+	Host        string                   `json:"host"`
+	Proto       string                   `json:"proto,omitempty"`
 	ClientIP    string                   `json:"clientIP"`
 	ClientID    string                   `json:"clientID,omitempty"`
 	HTTP        *HTTPRecorderObject      `json:"http,omitempty"`
@@ -113,6 +115,10 @@ type HandlerRecorderObject struct {
 func (p *HandlerRecorderObject) Record(ctx context.Context, r recorder.Recorder) error {
 	if p == nil || r == nil || p.Time.IsZero() {
 		return nil
+	}
+
+	if p.Labels == nil {
+		p.Labels = xctx.LabelsFromContext(ctx)
 	}
 
 	data, err := json.Marshal(p)

--- a/service/service.go
+++ b/service/service.go
@@ -43,6 +43,7 @@ type options struct {
 	observer       observer.Observer
 	observerPeriod time.Duration
 	logger         logger.Logger
+	labels         map[string]string
 }
 
 // Option is a functional option for configuring a service.
@@ -110,6 +111,14 @@ func ObserverOption(observer observer.Observer) Option {
 func ObserverPeriodOption(period time.Duration) Option {
 	return func(opts *options) {
 		opts.observerPeriod = period
+	}
+}
+
+// LabelsOption sets the static labels attached to the service's records
+// and logs.
+func LabelsOption(labels map[string]string) Option {
+	return func(opts *options) {
+		opts.labels = labels
 	}
 }
 
@@ -244,6 +253,10 @@ func (s *defaultService) Serve() error {
 
 		sid := xid.New().String()
 		ctx = xctx.ContextWithSid(ctx, xctx.Sid(sid))
+
+		if len(s.options.labels) > 0 {
+			ctx = xctx.ContextWithLabels(ctx, s.options.labels)
+		}
 
 		log := s.options.logger.WithFields(map[string]any{
 			"sid": sid,


### PR DESCRIPTION
## Motivation

Today the only service-controlled value reaching a handler record is the service **name**, so
attributing telemetry to a tenant, account, or region means encoding those identifiers somewhere
external and correlating them downstream — e.g. packing them into the name and re-parsing it.
This adds a generic way to attach arbitrary static labels directly to a service's records and logs.

## What this adds

- **`ctx`**: `ContextWithLabels` / `LabelsFromContext` — carry labels on the per-connection
  context, mirroring `ContextWithSid`.
- **`service`**: `LabelsOption` and injection of labels into the per-connection context in the
  serve loop.
- **`recorder`**: `HandlerRecorderObject.Labels` (`json:"labels,omitempty"`), populated from the
  context in `Record()`. Filled centrally, so every handler emits labels with no per-handler change.
- **`config/parsing/service`**: reads `service.metadata.labels`, passes them via `LabelsOption`,
  and wraps the service logger so service/listener/handler log lines carry a nested `labels`
  field. New `MDKeyLabels = "labels"`.

## Config

```yaml
services:
  - name: example
    addr: :8080
    metadata:
      labels: { tenant: acme, region: eu }
    handler:  { type: http }
    listener: { type: tcp }
    recorders:
      - { name: r0, record: recorder.service.handler }
```

Record output gains: `{ "service":"example", "labels":{"tenant":"acme","region":"eu"}, … }`

## Compatibility

Fully additive. Without `metadata.labels`: the field is omitted from records (`omitempty`), the
logger is left unwrapped, and no signatures change.

## Out of scope

- **Prometheus metric dimensions** — a `*Vec`'s label set is fixed at registration while services
  are created at runtime, so metric label keys must come from static startup config, not
  per-service metadata. Records and logs have no such constraint.
- **`handler/file`** — serves on a detached `http.Server`, so the per-connection context never
  reaches its records (it already omits sid and addresses for the same reason). Labels are absent
  there too; not a regression.
