### PR TITLE
fix(listener): keep *net.UDPConn visible to quic-go for GSO/GRO

### DIFF
--- a/listener/http3/wt/listener.go
+++ b/listener/http3/wt/listener.go
@@ -74,10 +74,12 @@ func (l *wtListener) Init(md md.Metadata) (err error) {
 		return
 	}
 
-	pc = metrics.WrapPacketConn(l.options.Service, pc)
-	pc = stats.WrapPacketConn(pc, l.options.Stats)
-	pc = admission.WrapPacketConn(l.options.Admission, pc)
-	pc = limiter_wrapper.WrapPacketConn(
+	pc = metrics.WrapUDPConn(l.options.Service, pc)
+	if l.options.Stats != nil {
+		pc = stats.WrapUDPConn(pc, l.options.Stats)
+	}
+	pc = admission.WrapUDPConn(l.options.Admission, pc)
+	pc = limiter_wrapper.WrapUDPConn(
 		pc,
 		l.options.TrafficLimiter,
 		traffic_limiter.ServiceLimitKey,

--- a/listener/quic/listener.go
+++ b/listener/quic/listener.go
@@ -70,19 +70,32 @@ func (l *quicListener) Init(md md.Metadata) (err error) {
 	}
 	if l.md.cipherKey != nil {
 		conn = quic_util.CipherPacketConn(conn, l.md.cipherKey)
+		conn = metrics.WrapPacketConn(l.options.Service, conn)
+		conn = stats.WrapPacketConn(conn, l.options.Stats)
+		conn = admission.WrapPacketConn(l.options.Admission, conn)
+		conn = limiter_wrapper.WrapPacketConn(
+			conn,
+			l.options.TrafficLimiter,
+			traffic_limiter.ServiceLimitKey,
+			limiter.ScopeOption(limiter.ScopeService),
+			limiter.ServiceOption(l.options.Service),
+			limiter.NetworkOption(conn.LocalAddr().Network()),
+		)
+	} else {
+		conn = metrics.WrapUDPConn(l.options.Service, conn)
+		if l.options.Stats != nil {
+			conn = stats.WrapUDPConn(conn, l.options.Stats)
+		}
+		conn = admission.WrapUDPConn(l.options.Admission, conn)
+		conn = limiter_wrapper.WrapUDPConn(
+			conn,
+			l.options.TrafficLimiter,
+			traffic_limiter.ServiceLimitKey,
+			limiter.ScopeOption(limiter.ScopeService),
+			limiter.ServiceOption(l.options.Service),
+			limiter.NetworkOption(conn.LocalAddr().Network()),
+		)
 	}
-
-	conn = metrics.WrapPacketConn(l.options.Service, conn)
-	conn = stats.WrapPacketConn(conn, l.options.Stats)
-	conn = admission.WrapPacketConn(l.options.Admission, conn)
-	conn = limiter_wrapper.WrapPacketConn(
-		conn,
-		l.options.TrafficLimiter,
-		traffic_limiter.ServiceLimitKey,
-		limiter.ScopeOption(limiter.ScopeService),
-		limiter.ServiceOption(l.options.Service),
-		limiter.NetworkOption(conn.LocalAddr().Network()),
-	)
 
 	config := &quic.Config{
 		KeepAlivePeriod:      l.md.keepAlivePeriod,


### PR DESCRIPTION
## Problem

The `quic` and `wt` (WebTransport) listeners wrap the raw UDP socket with the `net.PacketConn` metrics / stats / admission / limiter wrappers before handing it to quic-go (`quic.ListenEarly` and `http3.Server.Serve`):

```go
conn = metrics.WrapPacketConn(l.options.Service, conn)
conn = stats.WrapPacketConn(conn, l.options.Stats)
conn = admission.WrapPacketConn(l.options.Admission, conn)
conn = limiter_wrapper.WrapPacketConn(conn, ...)
ln, err := quic.ListenEarly(conn, tlsCfg, config)
```

`WrapPacketConn` returns a plain `net.PacketConn`, which hides the underlying `*net.UDPConn`. quic-go probes the conn for `OOBCapablePacketConn` (`SyscallConn`, `SetReadBuffer`, `ReadMsgUDP`, `WriteMsgUDP`); behind the wrapper that probe fails, so quic-go disables its kernel offloads and cannot size its receive buffer:

```
connection doesn't allow setting of receive buffer size. Not a *net.UDPConn?
PacketConn is not a net.UDPConn. Disabling optimizations possible on UDP connections.
```

The result is no GSO/GRO and an undersized UDP receive buffer, which caps QUIC throughput well below the TLS listener.

## Fix

The wrapper packages already ship `udp.Conn` variants (`WrapUDPConn`) that forward `SyscallConn` / `SetReadBuffer` / `ReadMsgUDP` / `WriteMsgUDP` down to the underlying `*net.UDPConn`. This switches the non-cipher path of both listeners to those wrappers, so quic-go sees an `OOBCapablePacketConn` and keeps GSO/GRO + buffer sizing, while the same metrics / stats / admission / limiting still apply.

The `quic` listener's cipher path keeps the `net.PacketConn` wrappers, since `CipherPacketConn` is not OOB-capable.

## Result

Single-hop QUIC relay, x86 / loopback / iperf3:

| streams | before | after |
|--------:|-------:|------:|
| 1 | 1.80 Gbit/s | 2.69 Gbit/s |
| 4 | 1.63 Gbit/s | 2.41 Gbit/s |
| 8 | 1.51 Gbit/s | 2.23 Gbit/s |

~+48% throughput, and the quic-go receive-buffer warning is gone (the wrapped conn now satisfies `OOBCapablePacketConn`).