### PR TITLE
Fix utls dialer dropping TLS config (invalid crypto/tls→utls cast)

### DIFF
--- a/dialer/utls/dialer.go
+++ b/dialer/utls/dialer.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"net"
 	"time"
-	"unsafe"
 
 	"github.com/go-gost/core/dialer"
 	"github.com/go-gost/core/logger"
@@ -82,7 +81,7 @@ func (d *utlsDialer) Handshake(ctx context.Context, conn net.Conn, options ...di
 	clientHelloID, ok := GetClientHelloID(d.md.fingerprint)
 	if ok {
 		d.log.Debugf("utls handshake with fingerprint: %s", d.md.fingerprint)
-		utlsCfg := (*utls.Config)(unsafe.Pointer(d.options.TLSConfig))
+		utlsCfg := toUTLSConfig(d.options.TLSConfig)
 		uconn := utls.UClient(conn, utlsCfg, clientHelloID)
 		if err := uconn.HandshakeContext(ctx); err != nil {
 			conn.Close()
@@ -103,4 +102,89 @@ func (d *utlsDialer) Handshake(ctx context.Context, conn net.Conn, options ...di
 	}
 
 	return tlsConn, nil
+}
+
+// toUTLSConfig builds an equivalent utls.Config from a standard crypto/tls.Config.
+//
+// utls.Config is a distinct type from crypto/tls.Config and its field offsets
+// diverge from ServerName onward (crypto/tls added fields utls does not have),
+// so a direct (*utls.Config)(unsafe.Pointer(...)) reinterprets memory and reads
+// garbage for ServerName/InsecureSkipVerify — which is what broke TLS
+// verification for this dialer. We copy fields explicitly instead.
+//
+// Fields whose types differ between the two packages (Certificate, ClientAuth,
+// CurveID, RenegotiationSupport, ConnectionState, the Get* callbacks,
+// ClientSessionCache) are converted or skipped: the config path that feeds this
+// dialer (LoadClientConfig) never populates the Get*/ClientSessionCache
+// callbacks, so skipping them is safe here.
+func toUTLSConfig(c *tls.Config) *utls.Config {
+	if c == nil {
+		return &utls.Config{}
+	}
+
+	uc := &utls.Config{
+		Rand:                        c.Rand,
+		Time:                        c.Time,
+		Certificates:                toUTLSCertificates(c.Certificates),
+		RootCAs:                     c.RootCAs,
+		NextProtos:                  c.NextProtos,
+		ServerName:                  c.ServerName,
+		ClientAuth:                  utls.ClientAuthType(c.ClientAuth),
+		ClientCAs:                   c.ClientCAs,
+		InsecureSkipVerify:          c.InsecureSkipVerify,
+		CipherSuites:                c.CipherSuites,
+		PreferServerCipherSuites:    c.PreferServerCipherSuites,
+		SessionTicketsDisabled:      c.SessionTicketsDisabled,
+		CurvePreferences:            toUTLSCurveIDs(c.CurvePreferences),
+		DynamicRecordSizingDisabled: c.DynamicRecordSizingDisabled,
+		Renegotiation:               utls.RenegotiationSupport(c.Renegotiation),
+		KeyLogWriter:                c.KeyLogWriter,
+		MinVersion:                  c.MinVersion,
+		MaxVersion:                  c.MaxVersion,
+		VerifyPeerCertificate:       c.VerifyPeerCertificate,
+	}
+
+	if c.VerifyConnection != nil {
+		vc := c.VerifyConnection
+		uc.VerifyConnection = func(cs utls.ConnectionState) error {
+			return vc(tls.ConnectionState{
+				PeerCertificates: cs.PeerCertificates,
+			})
+		}
+	}
+
+	return uc
+}
+
+func toUTLSCertificates(certs []tls.Certificate) []utls.Certificate {
+	if certs == nil {
+		return nil
+	}
+	out := make([]utls.Certificate, len(certs))
+	for i, c := range certs {
+		sa := make([]utls.SignatureScheme, len(c.SupportedSignatureAlgorithms))
+		for j, s := range c.SupportedSignatureAlgorithms {
+			sa[j] = utls.SignatureScheme(s)
+		}
+		out[i] = utls.Certificate{
+			Certificate:                  c.Certificate,
+			PrivateKey:                   c.PrivateKey,
+			SupportedSignatureAlgorithms: sa,
+			OCSPStaple:                   c.OCSPStaple,
+			SignedCertificateTimestamps:  c.SignedCertificateTimestamps,
+			Leaf:                         c.Leaf,
+		}
+	}
+	return out
+}
+
+func toUTLSCurveIDs(ids []tls.CurveID) []utls.CurveID {
+	if ids == nil {
+		return nil
+	}
+	out := make([]utls.CurveID, len(ids))
+	for i, id := range ids {
+		out[i] = utls.CurveID(id)
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

The `utls` dialer constructed its handshake config with

```go
utlsCfg := (*utls.Config)(unsafe.Pointer(d.options.TLSConfig))
```

`crypto/tls.Config` and `utls.Config` are distinct types whose field offsets **diverge from `ServerName` onward**:

| Field | `tls.Config` offset | `utls.Config` offset |
|-------|------|------|
| `ServerName` | 128 | 136 |
| `InsecureSkipVerify` | 160 | 168 |

The cast therefore reinterpreted memory and read garbage for `ServerName`/`InsecureSkipVerify`. `LoadClientConfig` correctly sets `InsecureSkipVerify = !secure` (→ `true` for `secure: false`), but the cast discarded it, so utls saw `InsecureSkipVerify: false` with an empty `ServerName` and the handshake failed with:

```
tls: at least one of ServerName, InsecureSkipVerify or InsecureServerNameToVerify must be specified in the tls.Config
```

Reported in go-gost/gost#887.

## Fix

Replaced the cast with `toUTLSConfig`, which copies fields explicitly and converts the types that differ between the two packages (`Certificate`, `ClientAuth`, `CurveID`, `RenegotiationSupport`, and the `VerifyConnection` callback's `ConnectionState`). The `Get*` callbacks and `ClientSessionCache` are skipped — the config path that feeds this dialer (`LoadClientConfig`) never populates them.

## Verification

- `go build ./...` and `go vet ./...` pass for the `x` module.
- A temporary test confirmed `ServerName`, `InsecureSkipVerify`, `RootCAs`, `CipherSuites`, `MinVersion`/`MaxVersion`, and `NextProtos` are carried through the conversion correctly (removed afterward, since `x/` has no test convention).

Refs go-gost/gost#887.