### PR TITLE
fix(utls): map curve preferences to utls-supported set, drop PQC hybrids

### DIFF
--- a/dialer/utls/dialer.go
+++ b/dialer/utls/dialer.go
@@ -178,13 +178,34 @@ func toUTLSCertificates(certs []tls.Certificate) []utls.Certificate {
 	return out
 }
 
+// utlsCurves maps the crypto/tls curve IDs that utls understands.
+//
+// crypto/tls and utls use separate CurveID enumerations. Go has added
+// post-quantum hybrid curves (X25519MLKEM768, SecP256r1MLKEM768,
+// SecP384r1MLKEM1024) whose numeric IDs utls does not recognise, so a
+// blind utls.CurveID(id) cast turns them into unsupported curve IDs and
+// aborts the handshake with "CurvePreferences includes unsupported curve".
+// We keep only the curves utls can actually use and drop the rest; if none
+// survive, return nil so utls falls back to the fingerprint's defaults.
+var utlsCurves = map[tls.CurveID]utls.CurveID{
+	tls.X25519:   utls.X25519,
+	tls.CurveP256: utls.CurveP256,
+	tls.CurveP384: utls.CurveP384,
+	tls.CurveP521: utls.CurveP521,
+}
+
 func toUTLSCurveIDs(ids []tls.CurveID) []utls.CurveID {
-	if ids == nil {
+	if len(ids) == 0 {
 		return nil
 	}
-	out := make([]utls.CurveID, len(ids))
-	for i, id := range ids {
-		out[i] = utls.CurveID(id)
+	out := make([]utls.CurveID, 0, len(ids))
+	for _, id := range ids {
+		if c, ok := utlsCurves[id]; ok {
+			out = append(out, c)
+		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

Go's `crypto/tls` (1.24+) appends post-quantum hybrid curves to the default `CurvePreferences`:
- `X25519MLKEM768`
- `SecP256r1MLKEM768`
- `SecP384r1MLKEM1024`

`toUTLSCurveIDs` blindly cast each `crypto/tls.CurveID` to `utls.CurveID`, but the two enums diverge — `utls` v1.8.x does not define the two `SecP*` hybrids. The cast produced unsupported curve IDs, so the handshake aborted with `tls: CurvePreferences includes unsupported curve`.

This is the **curve half** of #887. The first half (the invalid `unsafe.Pointer` cast that dropped `ServerName`/`InsecureSkipVerify`) was fixed in #111; this fixes the remaining field that cannot be copied by numeric cast.

## Fix

Translate only the four curves `utls` understands (`X25519`, `P256`, `P384`, `P521`) and drop the rest. When none survive, return `nil` so `utls` falls back to the fingerprint's defaults.

## Verification

- `go build ./...` and `go vet ./dialer/utls/` pass.
- Covered by the e2e regression suite added in go-gost/gost (utls forward-proxy chain over a TLS listener).

Related: go-gost/gost#887