### PR TITLE
fix(conn-limiter): release limiter slot once on Close

### DIFF
--- a/limiter/conn/wrapper/conn.go
+++ b/limiter/conn/wrapper/conn.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync/atomic"
 	"syscall"
 
 	limiter "github.com/go-gost/core/limiter/conn"
@@ -21,6 +22,7 @@ var (
 type serverConn struct {
 	net.Conn
 	limiter limiter.Limiter
+	closed  atomic.Bool // release the limiter slot once, even if Close is called more than once
 }
 
 // WrapConn wraps a net.Conn with a connection limiter. On Close, the
@@ -52,7 +54,9 @@ func (c *serverConn) SyscallConn() (rc syscall.RawConn, err error) {
 }
 
 func (c *serverConn) Close() error {
-	c.limiter.Allow(-1)
+	if c.closed.CompareAndSwap(false, true) {
+		c.limiter.Allow(-1)
+	}
 	return c.Conn.Close()
 }
 


### PR DESCRIPTION
serverConn.Close() called limiter.Allow(-1) on every invocation. Close is routinely called more than once (deferred + explicit teardown paths), so each extra call leaked a limiter slot, progressively under-counting the current connection count until the climiter cap admitted more connections than configured.

Guard the release behind an atomic.Bool CAS so the slot is returned exactly once, regardless of how many times Close is called.