### PR TITLE
fix(redirect): check bypass on dstAddr before sniffing

### DIFF
--- a/handler/redirect/tcp/handler.go
+++ b/handler/redirect/tcp/handler.go
@@ -142,6 +142,14 @@ func (h *redirectHandler) Handle(ctx context.Context, conn net.Conn, opts ...han
 		"host": dstAddr.String(),
 	})
 
+	// Check bypass on dstAddr before sniffing — the sniffer only matches the
+	// sniffed req.Host, so IP/CIDR rules miss connections carrying a hostname.
+	if h.options.Bypass != nil &&
+		h.options.Bypass.Contains(ctx, dstAddr.Network(), dstAddr.String(), bypass.WithService(h.options.Service)) {
+		log.Debug("bypass: ", dstAddr)
+		return xbypass.ErrBypass
+	}
+
 	if h.md.sniffing {
 		if h.md.sniffingTimeout > 0 {
 			conn.SetReadDeadline(time.Now().Add(h.md.sniffingTimeout))
@@ -228,12 +236,6 @@ func (h *redirectHandler) Handle(ctx context.Context, conn net.Conn, opts ...han
 	}
 
 	log.Debugf("%s >> %s", conn.RemoteAddr(), dstAddr)
-
-	if h.options.Bypass != nil &&
-		h.options.Bypass.Contains(ctx, dstAddr.Network(), dstAddr.String(), bypass.WithService(h.options.Service)) {
-		log.Debug("bypass: ", dstAddr)
-		return xbypass.ErrBypass
-	}
 
 	var buf bytes.Buffer
 	cc, err := h.options.Router.Dial(ictx.ContextWithBuffer(ctx, &buf), dstAddr.Network(), dstAddr.String())


### PR DESCRIPTION
When sniffing was enabled, the redirect handler returned inside the sniffing block for HTTP/TLS connections and never reached the late dstAddr bypass check. The sniffer's internal bypass matches on the sniffed req.Host, so an IP/CIDR bypass rule never matched a connection whose HTTP request carried a hostname — the connection was proxied even though its L4 destination was explicitly bypassed.

Move the dstAddr bypass check to before the sniffing block so IP/CIDR rules are honored on every path. The sniffer's hostname-based check still runs, covering the complementary match dimension. The old post-sniffing check had an identical condition and is now redundant, so drop it.