### PR TITLE
feat(redirect): add sniffing.dialOriginalDst flag

### DIFF
--- a/handler/redirect/tcp/handler.go
+++ b/handler/redirect/tcp/handler.go
@@ -187,6 +187,18 @@ func (h *redirectHandler) Handle(ctx context.Context, conn net.Conn, opts ...han
 
 			return cc, err
 		}
+
+		// Dial the original dst instead of the sniffed host; sniffing's
+		// hostname bypass and recording still run beforehand.
+		if h.md.sniffingDialOriginalDst {
+			dial = func(ctx context.Context, network, address string) (net.Conn, error) {
+				var buf bytes.Buffer
+				cc, err := h.options.Router.Dial(ictx.ContextWithBuffer(ctx, &buf), "tcp", dstAddr.String())
+				ro.Route = buf.String()
+				return cc, err
+			}
+		}
+
 		dialTLS := func(ctx context.Context, network, address string, cfg *tls.Config) (net.Conn, error) {
 			return dial(ctx, network, address)
 		}

--- a/handler/redirect/tcp/metadata.go
+++ b/handler/redirect/tcp/metadata.go
@@ -24,6 +24,7 @@ type metadata struct {
 	sniffing                    bool
 	sniffingTimeout             time.Duration
 	sniffingFallback            bool
+	sniffingDialOriginalDst     bool
 	sniffingWebsocket           bool
 	sniffingWebsocketSampleRate float64
 
@@ -43,6 +44,7 @@ func (h *redirectHandler) parseMetadata(md mdata.Metadata) (err error) {
 	h.md.sniffing = mdutil.GetBool(md, "sniffing")
 	h.md.sniffingTimeout = mdutil.GetDuration(md, "sniffing.timeout")
 	h.md.sniffingFallback = mdutil.GetBool(md, "sniffing.fallback")
+	h.md.sniffingDialOriginalDst = mdutil.GetBool(md, "sniffing.dialOriginalDst")
 	h.md.sniffingWebsocket = mdutil.GetBool(md, "sniffing.websocket")
 	h.md.sniffingWebsocketSampleRate = mdutil.GetFloat(md, "sniffing.websocket.sampleRate")
 


### PR DESCRIPTION
With sniffing enabled, the redirect handler dials the sniffed hostname (HTTP Host / TLS SNI). When the SNI/Host does not resolve — or resolves differently — from the box running gost, the connection drifts to the wrong destination.

Add an opt-in metadata flag sniffing.dialOriginalDst that dials the original transparent-redirect destination address instead, while sniffing still runs for hostname-bypass matching and recording. No default behavior change when the flag is unset.