### PR TITLE
feat(metrics): add gost_service_status gauge

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -29,6 +29,8 @@ const (
 	MetricChainErrorsCounter metrics.MetricName = "gost_chain_errors_total"
 	// Total recorder records. Labels: host, recorder.
 	MetricRecorderRecordsCounter metrics.MetricName = "gost_recorder_records_total"
+	// Number of services in each state. Labels: host, state.
+	MetricServiceStatusGauge metrics.MetricName = "gost_service_status"
 )
 
 var (

--- a/metrics/prom.go
+++ b/metrics/prom.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"maps"
 	"os"
+	"sync"
 
 	"github.com/go-gost/core/metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -143,4 +144,50 @@ func (m *promMetrics) Observer(name metrics.MetricName, labels metrics.Labels) m
 	maps.Copy(plabels, labels)
 	plabels["host"] = m.host
 	return v.With(plabels)
+}
+
+// ServiceStatusFunc returns the number of services in each state, keyed by
+// state name (e.g. "running", "ready", "failed", "closed").
+type ServiceStatusFunc func() map[string]float64
+
+var (
+	serviceStatusCollector     *serviceStatusGaugeCollector
+	serviceStatusCollectorOnce sync.Once
+)
+
+// RegisterServiceStatusFunc registers a callback invoked at each scrape to
+// collect the aggregate service status counts, exposed as MetricServiceStatusGauge.
+func RegisterServiceStatusFunc(fn ServiceStatusFunc) {
+	serviceStatusCollectorOnce.Do(func() {
+		host, _ := os.Hostname()
+		serviceStatusCollector = &serviceStatusGaugeCollector{
+			desc: prometheus.NewDesc(
+				string(MetricServiceStatusGauge),
+				"Number of services in each state",
+				[]string{"host", "state"},
+				nil,
+			),
+			host: host,
+			fn:   fn,
+		}
+		defaultRegistry.MustRegister(serviceStatusCollector)
+	})
+}
+
+// serviceStatusGaugeCollector implements prometheus.Collector, emitting the
+// MetricServiceStatusGauge counts from fn at each scrape.
+type serviceStatusGaugeCollector struct {
+	desc *prometheus.Desc
+	host string
+	fn   ServiceStatusFunc
+}
+
+func (c *serviceStatusGaugeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.desc
+}
+
+func (c *serviceStatusGaugeCollector) Collect(ch chan<- prometheus.Metric) {
+	for state, count := range c.fn() {
+		ch <- prometheus.MustNewConstMetric(c.desc, prometheus.GaugeValue, count, c.host, state)
+	}
 }


### PR DESCRIPTION
Expose a gost_service_status{host,state} gauge with the number of services per state (ready/running/failed/closed), collected at scrape time via a registered callback that aggregates over the service registry. Lets alerting catch dead/failed services without scraping the config API.

The callback is registered via RegisterServiceStatusFunc and wired by the app against registry.ServiceRegistry(). The collector registers on the custom defaultRegistry (which the metrics endpoint serves from), not the global prometheus registry.