### PR TITLE
fixed the issue where the pull request to exit and subsequent application writes to fail immediately in gost

### DIFF
--- a/internal/util/pht/client.go
+++ b/internal/util/pht/client.go
@@ -32,7 +32,7 @@ func (c *Client) Dial(ctx context.Context, addr string) (net.Conn, error) {
 		addr = net.JoinHostPort(c.Host, strconv.Itoa(raddr.Port))
 	}
 
-	connCtx, cancel := context.WithCancel(ctx)
+	connCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	cid := xid.New().String()
 	cn := &clientConn{
 		client:     c.Client,


### PR DESCRIPTION
`gost` aborts the established tunnel. 

A workaround can be used by adding `dialTimeout: -1s`
```
services:
  - name: local-proxy
    addr: 127.0.0.1:1080

    metadata:
      # Work around H3/PHT dial-context cancellation.
      dialTimeout: -1s
```

But this change seems to have solved the root cause.