### PR TITLE
x: stream websocket reads instead of buffering each frame

### DIFF
--- a/internal/util/ws/ws.go
+++ b/internal/util/ws/ws.go
@@ -2,6 +2,7 @@ package ws
 
 import (
 	"context"
+	"io"
 	"net"
 	"sync"
 	"time"
@@ -21,7 +22,7 @@ type WebsocketConn interface {
 
 type websocketConn struct {
 	*websocket.Conn
-	rb  []byte
+	r   io.Reader
 	ctx context.Context
 	mux sync.Mutex
 }
@@ -44,12 +45,24 @@ func ContextConn(ctx context.Context, conn *websocket.Conn) WebsocketConn {
 }
 
 func (c *websocketConn) Read(b []byte) (n int, err error) {
-	if len(c.rb) == 0 {
-		_, c.rb, err = c.Conn.ReadMessage()
+	for {
+		if c.r == nil {
+			_, c.r, err = c.Conn.NextReader()
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		n, err = c.r.Read(b)
+		if err == io.EOF {
+			c.r = nil
+			if n > 0 {
+				return n, nil
+			}
+			continue
+		}
+		return n, err
 	}
-	n = copy(b, c.rb)
-	c.rb = c.rb[n:]
-	return
 }
 
 func (c *websocketConn) Write(b []byte) (n int, err error) {


### PR DESCRIPTION
websocketConn.Read called Conn.ReadMessage, which is NextReader plus io.ReadAll. io.ReadAll starts at 512 bytes and grows by doubling, so every frame allocated a fresh slice and a chain of intermediate ones: a stream of 64KB frames costs about 2.5 bytes of garbage per byte carried, even though the caller already supplied a buffer to copy into.

On a relay+wss tunnel moving 750MB this was 2526KB of garbage per MB of payload and 757 GC cycles in 15 seconds against a 1.5MB live heap. An allocation profile attributed 99.92% of all process garbage to io.ReadAll under ReadMessage; a CPU profile spent 15% in memclrNoHeapPointers and ~21% in the collector, against 8% in AES-GCM.

Use NextReader and copy straight into the caller's buffer. The reader is kept across calls and dropped at end of message, so a message larger than the caller's buffer is still delivered across successive reads.

This also fixes a zero-length message surfacing as a (0, nil) read, which io.Copy counts as no progress and rejects after 100 in a row.

Benchmark on 64KB frames:

    before  39267 ns/op  1668.97 MB/s  138444 B/op  19 allocs/op
    after   19920 ns/op  3289.98 MB/s      80 B/op   3 allocs/op