### PR TITLE
cmd: keep absolute unix socket paths for path-based schemes

### DIFF
--- a/config/cmd/cmd.go
+++ b/config/cmd/cmd.go
@@ -397,8 +397,14 @@ func buildServiceConfig(url *url.URL) ([]*config.ServiceConfig, error) {
 		listener = schemes[1]
 	}
 
-	// For path-based protocols (Unix socket listeners and serial), use path as address
+	// Decide path-based from the scheme before registry remaps listener to tcp.
 	isPathBasedProtocol := listener == "unix" || listener == "runix" || listener == "serial"
+	for _, s := range schemes {
+		if s == "unix" || s == "runix" || s == "serial" {
+			isPathBasedProtocol = true
+			break
+		}
+	}
 
 	var addrs []string
 	if isPathBasedProtocol {
@@ -640,6 +646,18 @@ func buildNodeConfig(url *url.URL, m map[string]any) (*config.NodeConfig, error)
 		dialer = schemes[1]
 	}
 
+	// Path-based address logic must use the requested scheme, not the
+	// registry fallback (unix/serial often remap to http/tcp when only
+	// the CLI registry is partially populated, or in unit tests).
+	isPathBasedProtocol := dialer == "unix" || dialer == "serial" ||
+		connector == "unix" || connector == "serial"
+	for _, s := range schemes {
+		if s == "unix" || s == "serial" || s == "runix" {
+			isPathBasedProtocol = true
+			break
+		}
+	}
+
 	md := mdx.NewMetadata(m)
 
 	if c := registry.ConnectorRegistry().Get(connector); c == nil {
@@ -727,7 +745,6 @@ func buildNodeConfig(url *url.URL, m map[string]any) (*config.NodeConfig, error)
 
 	// For path-based protocols (Unix socket dialers and serial), use path as address
 	var nodeAddr string
-	isPathBasedProtocol := dialer == "unix" || dialer == "serial"
 	if isPathBasedProtocol {
 		path := url.EscapedPath()
 		if url.Host != "" {

--- a/config/cmd/cmd_test.go
+++ b/config/cmd/cmd_test.go
@@ -1765,10 +1765,10 @@ func TestBuildNodeConfig_TLSWithCert(t *testing.T) {
 	}
 }
 
-func TestBuildNodeConfig_UnixFallsBackToTCP(t *testing.T) {
+func TestBuildNodeConfig_UnixAbsolutePath(t *testing.T) {
 	// http+unix scheme: connector=http, dialer=unix.
-	// Since unix is not in the test registry, dialer falls back to tcp,
-	// and the path-based address logic (dialer=="unix") is skipped.
+	// Dialer falls back to tcp when unix is not in the test registry, but
+	// the absolute socket path from a three-slash URL must still be kept.
 	rawURL := "http+unix:///var/run/socket"
 	u, _ := url.Parse(rawURL)
 
@@ -1780,9 +1780,19 @@ func TestBuildNodeConfig_UnixFallsBackToTCP(t *testing.T) {
 	if node.Dialer.Type != "tcp" {
 		t.Errorf("Dialer.Type = %q, want tcp (unix not in test registry)", node.Dialer.Type)
 	}
-	// Addr is url.Host ("") since no host component in three-slash unix URL
-	if node.Addr != "" {
-		t.Errorf("Addr = %q, want empty", node.Addr)
+	if node.Addr != "/var/run/socket" {
+		t.Errorf("Addr = %q, want /var/run/socket", node.Addr)
+	}
+}
+
+func TestBuildNodeConfig_UnixRelativeHost(t *testing.T) {
+	u, _ := url.Parse("unix://docker.sock")
+	node, err := buildNodeConfig(u, map[string]any{})
+	if err != nil {
+		t.Fatalf("buildNodeConfig: %v", err)
+	}
+	if node.Addr != "docker.sock" {
+		t.Errorf("Addr = %q, want docker.sock", node.Addr)
 	}
 }
 


### PR DESCRIPTION
`-F unix:///var/run/docker.sock` (and `http+unix:///...`) could lose the path: path-based address handling ran only after the dialer/listener was remapped when `unix` was not in the registry, so `Addr` became empty and the hop had no nodes.

Use the original scheme components to decide path-based URLs, then keep absolute paths from three-slash forms.

Relates to go-gost/gost#893