### PR TITLE
fix(masque): repair server CONNECT-UDP relay

### DIFF
--- a/handler/masque/handler.go
+++ b/handler/masque/handler.go
@@ -368,9 +368,6 @@ func (h *masqueHandler) handleConnectUDP(ctx context.Context, w http.ResponseWri
 		return ErrDatagramNotSupport
 	}
 
-	// Get the underlying HTTP/3 stream
-	stream := streamer.HTTPStream()
-
 	// Get target connection - either through router/chain or direct
 	var targetPC net.PacketConn
 
@@ -393,15 +390,17 @@ func (h *masqueHandler) handleConnectUDP(ctx context.Context, w http.ResponseWri
 
 		ro.SrcAddr = c.LocalAddr().String()
 
-		// The connection from router should be a PacketConn (e.g., from masque connector)
-		if pc, ok := c.(net.PacketConn); ok {
-			targetPC = pc
-			log.Debugf("relaying UDP to %s via chain", targetAddr)
-		} else {
-			// Wrap as PacketConn if it's a regular Conn
-			targetPC = &connPacketConn{Conn: c, raddr: raddr}
-			log.Debugf("relaying UDP to %s via chain (wrapped)", targetAddr)
-		}
+		// Always wrap the router-returned conn as a point-to-point PacketConn
+		// that writes via Conn.Write against the fixed target. A direct UDP
+		// dial returns a *net.UDPConn that satisfies net.PacketConn but is
+		// pre-connected, so calling WriteTo on it fails with "use of WriteTo
+		// with pre-connected connection" and no packet ever reaches the target.
+		// Routing writes through Conn.Write works for both direct dials and
+		// stream-based upstream MASQUE connectors. The MASQUE target is fixed
+		// for the connection lifetime (parsed from the request path), so a
+		// single remote address is always correct.
+		targetPC = &connPacketConn{Conn: c, raddr: raddr}
+		log.Debugf("relaying UDP to %s via chain", targetAddr)
 	} else {
 		// Direct connection - create local UDP socket
 		directConn, err := net.ListenPacket("udp", "")
@@ -424,14 +423,17 @@ func (h *masqueHandler) handleConnectUDP(ctx context.Context, w http.ResponseWri
 	// Wrap target with metrics
 	targetPC = metrics.WrapPacketConn(h.options.Service, targetPC)
 
-	// Send success response with capsule-protocol header
+	// Send the success response WITH the mandatory Capsule-Protocol header
+	// (RFC 9298), then hijack the stream. HTTPStream() flushes the response
+	// internally and commits the headers, so Capsule-Protocol MUST be set
+	// before it; otherwise the client never sees Capsule-Protocol: ?1 and
+	// rejects the tunnel. Dialing the target first (above) means we only
+	// respond 200 once the relay path is ready, matching handleConnectTCP.
 	w.Header().Set("Capsule-Protocol", "?1")
 	w.WriteHeader(http.StatusOK)
 
-	// Flush the response headers
-	if flusher, ok := w.(http.Flusher); ok {
-		flusher.Flush()
-	}
+	// Hijack the underlying HTTP/3 stream for datagram exchange.
+	stream := streamer.HTTPStream()
 
 	// Create datagram connection wrapping the HTTP/3 stream (client side)
 	datagramConn := masque_util.NewDatagramConn(stream, laddr, raddr)


### PR DESCRIPTION
## Summary

The server-side MASQUE handler's `CONNECT-UDP` path (`handler/masque/handler.go`) is broken in two independent ways, so **no standards-compliant MASQUE client can establish a UDP tunnel** through GOST. TCP `CONNECT` is unaffected.

### Bug 1 — mandatory `Capsule-Protocol` response header is dropped

`handleConnectUDP` obtained the raw stream via `streamer.HTTPStream()` **before** setting the response headers. `HTTPStream()` calls `Flush()` internally, which commits a `200` response immediately; the subsequent `w.Header().Set("Capsule-Protocol", "?1")` then hits `if w.headerComplete { return }` in quic-go's `WriteHeader` and is silently ignored.

Per RFC 9298 the `2xx` response to a UDP-proxying request **must** carry `Capsule-Protocol: ?1`. Without it a compliant client (including GOST's own `connector/masque`, which checks for it) rejects the tunnel.

### Bug 2 — `WriteTo` on a pre-connected socket

For a direct target dial, `Router.Dial(ctx, "udp", target)` returns a connected `*net.UDPConn`. It satisfies `net.PacketConn`, so the old `if pc, ok := c.(net.PacketConn); ok { targetPC = pc }` branch used it directly and the UDP relay called `WriteTo(data, addr)` on it. Go rejects that with:

```
write udp ...: use of WriteTo with pre-connected connection
```

so **no packet ever reaches the target** and the client's datagrams time out.

## Fix

- Set `Capsule-Protocol: ?1` and `WriteHeader(200)` **before** hijacking the stream with `HTTPStream()`, and dial the target first — so we only respond `200` once the relay path is ready, matching `handleConnectTCP`.
- Always wrap the router-returned conn in the existing `connPacketConn` (which writes via `Conn.Write` against the fixed target). The MASQUE target is fixed for the connection lifetime (parsed from the request path), so a single remote address is always correct; this works for both direct dials and stream-based upstream MASQUE connectors.

Net diff is 19 insertions / 17 deletions in one file (mostly comments).

## Validation

- `go build ./handler/masque/...` and `go vet ./handler/masque/...` pass.
- Built the GOST CLI against this branch and ran a **standards-compliant HTTP/3 MASQUE client** (quic-go `http3.Transport`, Extended CONNECT `:protocol=connect-udp`, RFC 9298 path template, HTTP/3 datagrams) against `gost -L "masque+http3://user:pass@:port"`:

  | | before | after |
  |---|---|---|
  | `CONNECT-UDP` status | `200` | `200` |
  | `Capsule-Protocol` in response | *(missing)* | `?1` |
  | UDP datagram round-trip | ✗ timeout (`use of WriteTo…` on server) | ✓ echoes end-to-end |
  | `CONNECT-TCP` | ✓ | ✓ |

This makes GOST's MASQUE server interoperable with standard MASQUE clients (e.g. Surge's `masque` policy) for UDP, not just TCP.

## Scope

Server-side only (`handler/masque`). Does not overlap with #119 (client-side `connector/masque` SOCKS5-over-MASQUE).