### PR TITLE
feat(socks5): add optional UDP device binding

### DIFF
--- a/handler/socks/v5/metadata.go
+++ b/handler/socks/v5/metadata.go
@@ -27,6 +27,7 @@ type metadata struct {
 	enableUDP         bool
 	udpBufferSize     int
 	udpResolveDomain  bool
+	udpBindDevice     bool
 	udpBindMin        int
 	udpBindMax        int
 	compatibilityMode bool
@@ -63,6 +64,7 @@ func (h *socks5Handler) parseMetadata(md mdata.Metadata) (err error) {
 	h.md.enableUDP = mdutil.GetBool(md, "udp")
 	h.md.udpBufferSize = mdutil.GetInt(md, "udp.bufferSize", "udpBufferSize")
 	h.md.udpResolveDomain = mdutil.GetBool(md, "udp.resolveDomain", "udpResolveDomain")
+	h.md.udpBindDevice = mdutil.GetBool(md, "udp.bindDevice", "udpBindDevice")
 	h.md.udpBindMin = mdutil.GetInt(md, "udp.bindRange.min", "udp.minPort")
 	h.md.udpBindMax = mdutil.GetInt(md, "udp.bindRange.max", "udp.maxPort")
 

--- a/handler/socks/v5/udp.go
+++ b/handler/socks/v5/udp.go
@@ -74,7 +74,11 @@ func (h *socks5Handler) handleUDP(ctx context.Context, conn net.Conn, network st
 	// Verify the upstream chain is reachable before replying Success,
 	// per RFC 1928 §7.
 	var buf bytes.Buffer
-	c, err := h.options.Router.Dial(ictx.ContextWithBuffer(ctx, &buf), network, "") // UDP association
+	dialContext := ictx.ContextWithBuffer(ctx, &buf)
+	if h.md.udpBindDevice {
+		dialContext = ictx.ContextWithUDPBindDevice(dialContext)
+	}
+	c, err := h.options.Router.Dial(dialContext, network, "") // UDP association
 	ro.Route = buf.String()
 	if err != nil {
 		log.Error(err)
@@ -104,9 +108,9 @@ func (h *socks5Handler) handleUDP(ctx context.Context, conn net.Conn, network st
 	// as ATYP=Domain themselves and are left untouched.
 	if _, isDirect := pc.(*net.UDPConn); isDirect {
 		pc = &resolvePacketConn{
-			PacketConn:  pc,
-			resolver:    h.options.Router.Options().Resolver,
-			hostMapper:  h.options.Router.Options().HostMapper,
+			PacketConn: pc,
+			resolver:   h.options.Router.Options().Resolver,
+			hostMapper: h.options.Router.Options().HostMapper,
 		}
 	}
 

--- a/handler/socks/v5/udp_test.go
+++ b/handler/socks/v5/udp_test.go
@@ -7,7 +7,30 @@ import (
 	"testing"
 
 	xnet "github.com/go-gost/x/internal/net"
+	xmetadata "github.com/go-gost/x/metadata"
 )
+
+func TestParseMetadataUDPBindDevice(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "dotted", key: "udp.bindDevice"},
+		{name: "flat alias", key: "udpBindDevice"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := &socks5Handler{}
+			if err := h.parseMetadata(xmetadata.NewMetadata(map[string]any{test.key: true})); err != nil {
+				t.Fatal(err)
+			}
+			if !h.md.udpBindDevice {
+				t.Fatalf("%s did not enable UDP device binding", test.key)
+			}
+		})
+	}
+}
 
 func TestListenPacketInRange(t *testing.T) {
 	ctx := context.Background()

--- a/handler/socks/v5/udp_tun.go
+++ b/handler/socks/v5/udp_tun.go
@@ -69,7 +69,11 @@ func (h *socks5Handler) handleUDPTun(ctx context.Context, conn net.Conn, network
 
 		// obtain a udp connection
 		var buf bytes.Buffer
-		c, err := h.options.Router.Dial(ictx.ContextWithBuffer(ctx, &buf), network, "") // UDP association
+		dialContext := ictx.ContextWithBuffer(ctx, &buf)
+		if h.md.udpBindDevice {
+			dialContext = ictx.ContextWithUDPBindDevice(dialContext)
+		}
+		c, err := h.options.Router.Dial(dialContext, network, "") // UDP association
 		ro.Route = buf.String()
 		if err != nil {
 			log.Error(err)
@@ -114,9 +118,9 @@ func (h *socks5Handler) handleUDPTun(ctx context.Context, conn net.Conn, network
 	// resolved through the configured resolver instead of failing WriteTo.
 	if _, ok := pc.(*net.UDPConn); ok {
 		pc = &resolvePacketConn{
-			PacketConn:  pc,
-			resolver:    h.options.Router.Options().Resolver,
-			hostMapper:  h.options.Router.Options().HostMapper,
+			PacketConn: pc,
+			resolver:   h.options.Router.Options().Resolver,
+			hostMapper: h.options.Router.Options().HostMapper,
 		}
 	}
 

--- a/internal/ctx/value.go
+++ b/internal/ctx/value.go
@@ -13,6 +13,8 @@ import (
 
 type bufferKey struct{}
 
+type udpBindDeviceKey struct{}
+
 // ContextWithBuffer returns a copy of ctx with the given buffer stored.
 // The buffer is used by dialers and connectors to reuse a *bytes.Buffer
 // for protocol handshake data (e.g. TLS ClientHello, HTTP requests).
@@ -23,6 +25,19 @@ func ContextWithBuffer(ctx context.Context, buffer *bytes.Buffer) context.Contex
 // BufferFromContext returns the *bytes.Buffer stored in ctx, or nil.
 func BufferFromContext(ctx context.Context) *bytes.Buffer {
 	v, _ := ctx.Value(bufferKey{}).(*bytes.Buffer)
+	return v
+}
+
+// ContextWithUDPBindDevice marks an empty-address UDP relay dial as requiring
+// an operating-system device bind in addition to its local-address bind.
+func ContextWithUDPBindDevice(ctx context.Context) context.Context {
+	return context.WithValue(ctx, udpBindDeviceKey{}, true)
+}
+
+// UDPBindDeviceFromContext reports whether the UDP relay dial explicitly
+// requested an operating-system device bind.
+func UDPBindDeviceFromContext(ctx context.Context) bool {
+	v, _ := ctx.Value(udpBindDeviceKey{}).(bool)
 	return v
 }
 

--- a/internal/net/dialer/dialer.go
+++ b/internal/net/dialer/dialer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-gost/core/logger"
 	ctxvalue "github.com/go-gost/x/ctx"
+	ictx "github.com/go-gost/x/internal/ctx"
 	xnet "github.com/go-gost/x/internal/net"
 )
 
@@ -125,12 +126,15 @@ func (d *Dialer) dialOnce(ctx context.Context, network, addr, ifceName string, i
 				return nil, err
 			}
 			err = sc.Control(func(fd uintptr) {
-				// NOTE: bindDevice is intentionally skipped for empty-addr UDP
-				// (relay/listener sockets). The ListenUDP laddr binding above
-				// is sufficient to pin the source IP. SO_BINDTODEVICE would
-				// force all outbound datagrams through the named interface,
-				// which may conflict with the kernel routing table and cause
-				// silent packet drops — breaking UDP associate (issue #287).
+				// Keep the default from issue #287: an empty-address UDP relay
+				// binds only its source address. Multi-uplink hosts can opt into
+				// SO_BINDTODEVICE when their routing table would otherwise select
+				// a different egress interface.
+				if shouldBindUDPDevice(ctx, ifceName, bindToDevice) {
+					if err := bindDevice(network, addr, fd, ifceName); err != nil {
+						log.Warnf("%s/%s bind device: %v", addr, network, err)
+					}
+				}
 				if d.Mark != 0 {
 					if err := setMark(fd, d.Mark); err != nil {
 						log.Warnf("set mark: %v", err)
@@ -181,4 +185,8 @@ func (d *Dialer) dialOnce(ctx context.Context, network, addr, ifceName string, i
 	}
 
 	return netd.DialContext(ctx, network, addr)
+}
+
+func shouldBindUDPDevice(ctx context.Context, ifceName string, bindToDevice bool) bool {
+	return ictx.UDPBindDeviceFromContext(ctx) && ifceName != "" && bindToDevice
 }

--- a/internal/net/dialer/dialer_test.go
+++ b/internal/net/dialer/dialer_test.go
@@ -5,7 +5,26 @@ import (
 	"errors"
 	"net"
 	"testing"
+
+	ictx "github.com/go-gost/x/internal/ctx"
 )
+
+func TestShouldBindUDPDevice(t *testing.T) {
+	if shouldBindUDPDevice(context.Background(), "wwan0", true) {
+		t.Fatal("device binding must remain disabled by default")
+	}
+
+	ctx := ictx.ContextWithUDPBindDevice(context.Background())
+	if !shouldBindUDPDevice(ctx, "wwan0", true) {
+		t.Fatal("explicit UDP device binding was ignored")
+	}
+	if shouldBindUDPDevice(ctx, "", true) {
+		t.Fatal("device binding requires a resolved interface name")
+	}
+	if shouldBindUDPDevice(ctx, "wwan0", false) {
+		t.Fatal("an interface specified as an IP address must not use SO_BINDTODEVICE")
+	}
+}
 
 func TestDialer_Dial_DialFunc(t *testing.T) {
 	customErr := errors.New("custom dial")


### PR DESCRIPTION
## Summary

Add an opt-in `udp.bindDevice` metadata option for the SOCKS5 handler.

When a listener is configured with both a named `interface` and
`udp.bindDevice=true`, empty-address UDP relay sockets created for SOCKS5
`UDP ASSOCIATE` and UDP-TUN explicitly apply `SO_BINDTODEVICE`.

The default remains unchanged: without this option, empty-address UDP relay
sockets only bind the selected source address, preserving the behavior added
for go-gost/gost#287.

## Motivation

On a multi-uplink host, binding only the source address may not be enough when
policy routing still selects another egress interface. TCP sessions can leave
through the configured interface while SOCKS5 UDP relay packets are sent via
the default route and receive no replies.

This makes strict device binding an explicit per-handler choice instead of
changing the default globally.

## Usage

```shell
gost -L "socks5://user:pass@0.0.0.0:5690?udp=true&interface=wwan0&udp.bindDevice=true"
```

`interface=wwan0` selects the interface. `udp.bindDevice=true` opts the
SOCKS5 UDP relay sockets into OS-level device binding.

## Validation

- `go test ./internal/ctx ./internal/net/dialer ./handler/socks/v5`
- Verified SOCKS5 UDP ASSOCIATE DNS round trips on a multi-uplink Linux host
  where the default route uses a different interface.

The full `go test ./...` run still reports two failures that reproduce on the
unmodified upstream base: `handler/dns/TestInit_DefaultExchanger` and
`metrics/wrapper/TestWrapListenerAccept`.
